### PR TITLE
Add Codecov integration, update README badges, and fix coverage filter

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -31,6 +33,6 @@ jobs:
         run: bundle exec rake test:rspec
 
       - name: Upload coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        run: bash <(curl -s https://codecov.io/bash) -s coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,3 +29,8 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test:rspec
+
+      - name: Upload coverage to Codecov
+        run: bash <(curl -s https://codecov.io/bash)
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,12 +30,11 @@ jobs:
         run: bundle exec rubocop
 
       - name: Run tests
-        run: bundle exec rake test:rspec && ls -al coverage
-
-      - name: List coverage directory
-        run: ls -al coverage
+        run: bundle exec rake test:rspec
 
       - name: Upload coverage to Codecov
-        run: ls -al coverage && bash <(curl -s https://codecov.io/bash) -s coverage
+        run: bash <(curl -s https://codecov.io/bash)
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_EXCLUDE: "*.html,*.lock,assets" # Exclude non-report files
+

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,9 +30,12 @@ jobs:
         run: bundle exec rubocop
 
       - name: Run tests
-        run: bundle exec rake test:rspec
+        run: bundle exec rake test:rspec && ls -al coverage
+
+      - name: List coverage directory
+        run: ls -al coverage
 
       - name: Upload coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash) -s coverage
+        run: ls -al coverage && bash <(curl -s https://codecov.io/bash) -s coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,8 +33,6 @@ jobs:
         run: bundle exec rake test:rspec
 
       - name: Upload coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        run: bash <(curl -s https://codecov.io/bash) -f coverage/.resultset.json
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          CODECOV_EXCLUDE: "*.html,*.lock,assets" # Exclude non-report files
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # CanMessenger
 
+[![Gem Version](https://badge.fury.io/rb/can_messenger.svg?icon=si%3Arubygems&icon_color=%23e77682)](https://badge.fury.io/rb/can_messenger)
+[![Build Status](https://github.com/fk1018/can_messenger/actions/workflows/ruby.yml/badge.svg)](https://github.com/fk1018/can_messenger/actions)
+[![Test Coverage](https://codecov.io/gh/fk1018/can_messenger/branch/main/graph/badge.svg)](https://codecov.io/gh/fk1018/can_messenger)
+![Status](https://img.shields.io/badge/status-stable-green)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+![Gem Total Downloads](https://img.shields.io/gem/dt/can_messenger)
+
 `can_messenger` is a Ruby gem that provides an interface for communicating over the CAN bus, allowing users to send and receive CAN messages. This gem is designed for developers who need an easy way to interact with CAN-enabled devices.
 
 ## Installation

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# codecov.yml
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  paths:
+    - "coverage/.resultset.json"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,4 @@
 # codecov.yml
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
   paths:
-    - "coverage/.resultset.json"
+    - "coverage/.resultset.json" # specify the exact path

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -4,10 +4,10 @@
 require "simplecov"
 
 SimpleCov.start do
-  add_filter "/spec/"   # Exclude test files from coverage results
+  add_filter "/spec/"
 end
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __dir__)
-require "can_messenger" # This will load `lib/can_messenger/messenger.rb`
+require "can_messenger"
 
 require "rspec"

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -4,7 +4,7 @@
 require "simplecov"
 
 SimpleCov.start do
-  add_filter "/test/"   # Exclude test files from coverage results
+  add_filter "/spec/"   # Exclude test files from coverage results
 end
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __dir__)


### PR DESCRIPTION
This pull request includes several updates to improve the project's documentation, testing, and code coverage reporting. The most important changes are as follows:

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R9): Added badges for gem version, build status, test coverage, status, license, and total downloads to enhance the project's documentation and provide quick insights into the project's state.

### Testing and Coverage Enhancements:
* [`.github/workflows/ruby.yml`](diffhunk://#diff-ce0dee93a528f6c7648f4cd671a3ec7be6a80f976c88f3aa1c322b7a80828fbaR32-R36): Added a step to upload test coverage reports to Codecov after running tests.
* [`spec/test_helper.rb`](diffhunk://#diff-a791756ec2b7f79009d33cf4e7da50f25292ed5dd13f3aeb9c75570b919c4b8eL7-R7): Updated the SimpleCov configuration to exclude the `spec` directory instead of the `test` directory from coverage results.