### PR TITLE
Add filtering to start_listening and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.1.0] - 2024-11-10
 
 - Initial release
+
+## [0.2.0] - 2024-12-05
+
+### Added
+
+- Filtering support for `start_listening` via a `filter` parameter:
+  - Single CAN ID.
+  - Range of CAN IDs.
+  - Array of CAN IDs.
+
+### Changed
+
+- Refactored `start_listening` to support optional filtering of incoming CAN messages.
+- Documentation updates for `start_listening` in README.
+
+[0.2.0]: https://github.com/fk1018/can_messenger/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/fk1018/can_messenger/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ messenger = CanMessenger::Messenger.new('can0')
 
 To send a message:
 
-```ruby
-messenger.send_can_message(0x123, [0xDE, 0xAD, 0xBE, 0xEF])
-```
+    ```ruby
+    messenger.send_can_message(0x123, [0xDE, 0xAD, 0xBE, 0xEF])
+    ```
 
 ### Receiving CAN Messages
 
@@ -63,6 +63,36 @@ To listen for incoming messages, set up a listener:
 messenger.start_listening do |message|
     puts "Received: ID=#{message[:id]}, Data=#{message[:data]}"
 end
+```
+
+#### Listening with Filters
+
+The `start_listening` method supports filtering incoming messages based on CAN ID:
+
+Single CAN ID:
+
+```ruby
+messenger.start_listening(filter: 0x123) do |message|
+  puts "Received filtered message: #{message}"
+end
+```
+
+Range of CAN IDs:
+
+```ruby
+messenger.start_listening(filter: 0x100..0x200) do |message|
+  puts "Received filtered message: #{message}"
+end
+
+```
+
+Array of CAN IDs:
+
+```ruby
+messenger.start_listening(filter: [0x123, 0x456, 0x789]) do |message|
+  puts "Received filtered message: #{message}"
+end
+
 ```
 
 ### Stopping the Listener

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/lib/can_messenger/messenger_spec.rb
+++ b/spec/lib/can_messenger/messenger_spec.rb
@@ -142,4 +142,27 @@ RSpec.describe CanMessenger::Messenger do # rubocop:disable Metrics/BlockLength
       expect(parsed).to eq(id: 0x12345678, data: [0xDE, 0xAD, 0xBE, 0xEF])
     end
   end
+
+  describe "#matches_filter?" do
+    let(:messenger) { described_class.new("can0") }
+
+    it "returns true when the filter is nil" do
+      expect(messenger.send(:matches_filter?, 0x123, nil)).to eq(true)
+    end
+
+    it "matches a single CAN ID" do
+      expect(messenger.send(:matches_filter?, 0x123, 0x123)).to eq(true)
+      expect(messenger.send(:matches_filter?, 0x124, 0x123)).to eq(false)
+    end
+
+    it "matches a range of CAN IDs" do
+      expect(messenger.send(:matches_filter?, 0x123, 0x100..0x200)).to eq(true)
+      expect(messenger.send(:matches_filter?, 0x300, 0x100..0x200)).to eq(false)
+    end
+
+    it "matches an array of CAN IDs" do
+      expect(messenger.send(:matches_filter?, 0x123, [0x123, 0x124, 0x125])).to eq(true)
+      expect(messenger.send(:matches_filter?, 0x126, [0x123, 0x124, 0x125])).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces a new version (0.2.0) of the `can_messenger` library, adding support for filtering CAN messages in the `start_listening` method. It includes updates to the documentation, the implementation of the filtering feature, and corresponding tests. The most important changes are as follows:

### New Features:
* Added filtering support for `start_listening` via a `filter` parameter, which can be a single CAN ID, a range of CAN IDs, or an array of CAN IDs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R28) [[2]](diffhunk://#diff-b213b65cf6f2958daaf4722fb894a6330b0dcc4f86ca13081d5a8439962366e8L46-R62)

### Documentation Updates:
* Updated the `README.md` to include examples of using the `start_listening` method with filters.

### Implementation Changes:
* Refactored the `start_listening` method to support optional filtering of incoming CAN messages.
* Added a helper method `matches_filter?` to check if a message ID matches the given filter.

### Version Update:
* Updated the version in `lib/can_messenger/version.rb` to 0.2.0.

### Testing:
* Added tests for the `matches_filter?` method in `spec/lib/can_messenger/messenger_spec.rb`.