### PR TITLE
Add GitHub Actions workflow for publishing gem to RubyGems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Publish Gem to RubyGems
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Publish to RubyGems
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3 # Match your Ruby version
+
+      - name: Install Bundler
+        run: gem install bundler
+
+      - name: Build the gem
+        run: gem build can_messenger.gemspec
+
+      - name: Publish the gem
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push can_messenger-*.gem


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of the gem to RubyGems. The workflow is triggered on pushes to the main branch and includes steps to set up Ruby, install Bundler, build the gem, and publish it to RubyGems.

New GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R31): Added a new workflow named "Publish Gem to RubyGems" that runs on `ubuntu-latest`. It includes steps for checking out the code, setting up Ruby, installing Bundler, building the gem, and publishing the gem to RubyGems.