### PR TITLE
Fix environment variable name for RubyGems API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Publish the gem
         env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: gem push can_messenger-*.gem


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/release.yml` file. The change updates the environment variable name used for publishing the gem.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L30-R30): Changed `RUBYGEMS_API_KEY` to `GEM_HOST_API_KEY` in the `env` section for the `Publish the gem` job.