### PR TITLE
16 update the rbs for messenger to reflect the filters

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Gem to RubyGems
+name: Tag and Publish Gem to RubyGems
 
 on:
   push:
@@ -6,25 +6,45 @@ on:
       - main
 
 jobs:
-  release:
-    name: Publish to RubyGems
+  tag_and_release:
+    name: Tag and Publish to RubyGems
     runs-on: ubuntu-latest
 
     steps:
+      # Step 1: Checkout code
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Step 2: Extract version from version.rb
+      - name: Extract version from version.rb
+        id: version
+        run: |
+          version=$(ruby -r ./lib/can_messenger/version -e 'puts CanMessenger::VERSION')
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      # Step 3: Create and push tag
+      - name: Create and push tag
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Step 4: Set up Ruby
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3 # Match your Ruby version
 
+      # Step 5: Install Bundler
       - name: Install Bundler
         run: gem install bundler
 
+      # Step 6: Build the gem
       - name: Build the gem
         run: gem build can_messenger.gemspec
 
+      # Step 7: Publish the gem
       - name: Publish the gem
         env:
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ### Fixed
 
-## [0.1.0] - 2024-11-10
+## [0.2.1] - 2024-12-06
 
-- Initial release
+### Changed
+
+- Updated `start_listening` RBS signature to include the `filter` parameter, ensuring type definitions match the implementation.
 
 ## [0.2.0] - 2024-12-05
 
@@ -24,5 +26,10 @@
 - Refactored `start_listening` to support optional filtering of incoming CAN messages.
 - Documentation updates for `start_listening` in README.
 
+## [0.1.0] - 2024-11-10
+
+- Initial release
+
+[0.2.1]: https://github.com/fk1018/can_messenger/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/fk1018/can_messenger/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/fk1018/can_messenger/releases/tag/v0.1.0

--- a/can_messenger.gemspec
+++ b/can_messenger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/fk1018/can_messenger"
-  spec.metadata["changelog_uri"] = "https://github.com/fk1018/can_messenger/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/fk1018/can_messenger/blob/main/CHANGELOG.md"
 
   # Files to include in the gem package
   spec.files = Dir["lib/**/*", "README.md"]

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/sig/can_messenger/messenger.rbs
+++ b/sig/can_messenger/messenger.rbs
@@ -6,7 +6,7 @@ module CanMessenger
 
     def initialize: (String can_interface, ?Logger logger) -> void
     def send_can_message: (Integer id, Array[Integer] data) -> void
-    def start_listening: () { (Hash[:id => Integer, :data => Array[Integer]]) -> void } -> void
+    def start_listening: (?filter: (Integer | Range[Integer] | Array[Integer])?) { (Hash[:id => Integer, :data => Array[Integer]]) -> void } -> void
     def stop_listening: () -> void
 
     private


### PR DESCRIPTION
This pull request includes several updates and fixes to the `can_messenger` project, mainly focusing on version updates, documentation improvements, and method signature changes. The most important changes are summarized below:

### Version and Documentation Updates:
* Updated the version number in `lib/can_messenger/version.rb` from `0.2.0` to `0.2.1`.
* Updated the `CHANGELOG.md` to reflect the new version `0.2.1` and included a link to the comparison between versions `0.2.0` and `0.2.1`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL9-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR29-R33)
* Corrected the `changelog_uri` in `can_messenger.gemspec` to point to the correct URL.

### Method Signature Changes:
* Modified the RBS signature of the `start_listening` method to include an optional `filter` parameter, ensuring type definitions match the implementation.