### PR TITLE
Enhance Messenger Internal Listening Loop & Test Infrastructure (v0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ### Fixed
 
+## [0.2.3] - 2025-02-01
+
+### Changed
+
+- Updated the internal listening loop in `start_listening` to continue iterating on nil (timeout) responses instead of breaking out, improving reliability.
+- Suppressed log output during tests by injecting a silent logger.
+- Updated the test suite to better handle long-running listening loops and error conditions.
+
 ## [0.2.2] - 2024-12-06
 
 ### Changed

--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -56,8 +56,7 @@ module CanMessenger
       socket = create_socket
       while @listening
         message = receive_message(socket)
-        break unless message # Exit loop if no message
-
+        next if message.nil? # Skip if no message received
         next if filter && !matches_filter?(message[:id], filter) # Apply filter if specified
 
         yield(message)

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
# Overview

This update improves the internal behavior of the Messenger class and its tests without affecting the public API. The changes ensure more robust error handling and cleaner test output.
## Changes Made

    Listening Loop Behavior:
        Modified the start_listening method so that when a nil (timeout) is received, the loop continues instead of breaking prematurely.
        This ensures continuous listening until explicitly stopped via stop_listening.

    Error Handling Enhancements:
        Improved error logging in start_listening and related methods.
        Errors are now logged appropriately without halting the listening loop unexpectedly.

    Test Infrastructure Improvements:
        Updated the test suite to run the listening loop in a separate thread and explicitly call stop_listening, preventing infinite loops during testing.
        Injected a silent logger (using StringIO) into test instances to suppress cluttered log output, resulting in cleaner test results.

    Version & Changelog Updates:
        Bumped the version from 0.2.2 to 0.2.3 (a patch release, as the public API remains unchanged).
        Updated the CHANGELOG.md accordingly.

## Impact

These enhancements improve internal reliability and test robustness, making it easier to maintain the codebase while keeping the external interface intact.
