### PR TITLE
Update version to 1.0.1 and expand README with key details

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
     name: Tag and Publish to RubyGems
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write # REQUIRED for OIDC authentication
+      contents: write # Allows creating a tag and pushing it
+
     steps:
       # Step 1: Checkout code
       - name: Checkout code
@@ -34,7 +38,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3 # Match your Ruby version
+          ruby-version: 3.3
 
       # Step 5: Install Bundler
       - name: Install Bundler
@@ -44,8 +48,10 @@ jobs:
       - name: Build the gem
         run: gem build can_messenger.gemspec
 
-      # Step 7: Publish the gem
+      # Step 7: Authenticate to RubyGems using OIDC
+      - name: Authenticate to RubyGems
+        uses: rubygems/auth-action@v1
+
+      # Step 8: Publish the gem using OIDC
       - name: Publish the gem
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: gem push can_messenger-*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changed
 
 ### Fixed
+## [1.0.1] - 2025-02-09
+
+### Changed
+- Updated the README to include an **Important Considerations** section that outlines environment requirements, API changes (keyword arguments and block requirement), threading and socket management notes, and logging behavior.
+- Made minor documentation clarifications and tweaks to help users avoid common pitfalls.
 
 ## [1.0.0] - 2025-02-09
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ Before using `can_messenger`, please note the following:
 
 - **Environment Requirements:**
 
-  - **Linux Dependency:** This gem relies on Linux's native CAN socket interface and requires the `can-utils` package (specifically, the `cansend` command) to be installed.
-    ```bash
-    sudo apt install can-utils
-    ```
   - **Permissions:** Working with raw sockets may require elevated privileges or membership in a specific group to open and bind to CAN interfaces without running as root.
 
 - **API Changes (v1.0.0 and later):**

--- a/README.md
+++ b/README.md
@@ -103,6 +103,52 @@ To stop listening, use:
 messenger.stop_listening
 ```
 
+## Important Considerations
+
+Before using `can_messenger`, please note the following:
+
+- **Environment Requirements:**
+
+  - **Linux Dependency:** This gem relies on Linux's native CAN socket interface and requires the `can-utils` package (specifically, the `cansend` command) to be installed.
+    ```bash
+    sudo apt install can-utils
+    ```
+  - **Permissions:** Working with raw sockets may require elevated privileges or membership in a specific group to open and bind to CAN interfaces without running as root.
+
+- **API Changes (v1.0.0 and later):**
+
+  - **Keyword Arguments:** The Messenger API now requires keyword arguments. For example, when initializing the Messenger, use:
+    ```ruby
+    messenger = CanMessenger::Messenger.new(interface_name: 'can0')
+    ```
+    Similarly, methods like `send_can_message` now require named parameters:
+    ```ruby
+    messenger.send_can_message(id: 0x123, data: [0xDE, 0xAD, 0xBE, 0xEF])
+    ```
+    If you're upgrading from an earlier version, update your code accordingly.
+  - **Block Requirement for `start_listening`:**  
+    The `start_listening` method now requires a block. If no block is provided, the method logs an error and exits without processing messages. Ensure you pass a block to handle incoming CAN messages:
+    ```ruby
+    messenger.start_listening do |message|
+      # Process the message here
+      puts "Received: #{message}"
+    end
+    ```
+
+- **Threading & Socket Management:**
+
+  - **Blocking Behavior:** The gem uses blocking socket calls and continuously listens for messages. Be sure to manage the listener's lifecycle appropriately,especially if using it in a multi-threaded application. Always call `stop_listening` to gracefully shut down the listener.
+  - **Resource Cleanup:** The socket is automatically closed when the listening loop terminates. However, you should ensure that your application stops the listener to avoid resource leaks.
+
+- **Logging:**
+
+  - **Default Logger:** By default, if no logger is provided, the gem logs to standard output. For more controlled logging, pass a custom logger when initializing the Messenger.
+
+- **CAN Frame Format Assumptions:**
+  - The gem expects a standard CAN frame format with a minimum frame size and specific layout (e.g., the first 4 bytes for the CAN ID, followed by a byte indicating data length, etc.). If you work with non-standard frames, you may need to adjust the implementation.
+
+By keeping these points in mind, you can avoid common pitfalls and ensure that `can_messenger` is integrated smoothly into your project.
+
 ## Features
 
 - **Send CAN Messages**: Send CAN messages with a specified ID.

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Bump the gem version to 1.0.1 to reflect incremental updates. Enhance the README with critical usage notes, including environment setup, API changes, threading considerations, and logging behavior, to guide users more effectively. This improves clarity and reduces potential integration issues.