### PR TITLE
Replace `cansend` with raw-socket implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,34 @@
 
 ### Added
 
+- (Nothing since last release.)
+
 ### Changed
 
-### Fixed
+- (Nothing since last release.)
 
 ### Fixed
 
-- Reverted release.yml
+- (Nothing since last release.)
 
-## [1.0.1] - 2025-02-09
+## [1.1.0] - 2025-02-10
+
+### Changed
+
+- **Removed dependency on `cansend`**. We now write CAN frames directly via raw sockets.
+- Internal refactoring to support raw-socket–based sending without changing the public API.
+
+### Fixed
+
+## [1.0.3] - 2025-02-09
+
+- Revert release.yml
+
+### Fixed
+
+## [1.0.2] - 2025-02-09
+
+- Bugfix release.yml
 
 ## [1.0.1] - 2025-02-09
 
@@ -67,10 +86,12 @@
 ## [0.1.0] - 2024-11-10
 
 - Initial release
-
-[1.0.0]: https://github.com/fk1018/can_messenger/compare/v0.2.3...v1.0.0
-[0.2.3]: https://github.com/fk1018/can_messenger/compare/v0.2.2...v0.2.3
-[0.2.2]: https://github.com/fk1018/can_messenger/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/fk1018/can_messenger/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/fk1018/can_messenger/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/fk1018/can_messenger/releases/tag/v0.1.0
+  [1.1.0]: https://github.com/fk1018/can_messenger/compare/v1.0.3...v1.1.0
+  [1.0.3]: https://github.com/fk1018/can_messenger/compare/v1.0.1...v1.0.3
+  [1.0.1]: https://github.com/fk1018/can_messenger/compare/v1.0.0...v1.0.1
+  [1.0.0]: https://github.com/fk1018/can_messenger/compare/v0.2.3...v1.0.0
+  [0.2.3]: https://github.com/fk1018/can_messenger/compare/v0.2.2...v0.2.3
+  [0.2.2]: https://github.com/fk1018/can_messenger/compare/v0.2.1...v0.2.2
+  [0.2.1]: https://github.com/fk1018/can_messenger/compare/v0.2.0...v0.2.1
+  [0.2.0]: https://github.com/fk1018/can_messenger/compare/v0.1.0...v0.2.0
+  [0.1.0]: https://github.com/fk1018/can_messenger/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
 # CanMessenger
 
-[![Gem Version](https://badge.fury.io/rb/can_messenger.svg?icon=si%3Arubygems&icon_color=%23e77682)](https://badge.fury.io/rb/can_messenger)
+[![Gem Version](https://badge.fury.io/rb/can_messenger.svg?icon=si%3Arubygems&icon_color=%23e77682&123)](https://badge.fury.io/rb/can_messenger)
 [![Build Status](https://github.com/fk1018/can_messenger/actions/workflows/ruby.yml/badge.svg)](https://github.com/fk1018/can_messenger/actions)
 [![Test Coverage](https://codecov.io/gh/fk1018/can_messenger/branch/main/graph/badge.svg)](https://codecov.io/gh/fk1018/can_messenger)
 ![Status](https://img.shields.io/badge/status-stable-green)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![Gem Total Downloads](https://img.shields.io/gem/dt/can_messenger)
 
-`can_messenger` is a Ruby gem that provides an interface for communicating over the CAN bus, allowing users to send and receive CAN messages. This gem is designed for developers who need an easy way to interact with CAN-enabled devices.
+`can_messenger` is a Ruby gem that provides an interface for communicating over the CAN bus, allowing users to send and receive CAN messages `via raw SocketCAN sockets`. This gem is designed for developers who need an easy way to interact with CAN-enabled devices on Linux.
 
 ## Installation
 
-This gem relies on `cansend` from the `can-utils` package, which is typically available on Linux-based systems. Make sure to install `can-utils` before using `can_messenger`:
+Ensure you have `SocketCAN` available on your system. Typically on Linux (e.g., Debian/Ubuntu), you install SocketCAN support with:
 
 ```bash
-sudo apt install can-utils
+sudo apt-get install net-tools iproute2
+```
+
+Then bring up your CAN interface (e.g., `can0`) using `ip` commands or a tool like `can-utils` (though this gem no longer depends on `cansend`):
+
+```bash
+sudo ip link set can0 up type can bitrate 500000
 ```
 
 To install `can_messenger`, add it to your application's Gemfile:
@@ -55,13 +61,15 @@ To send a message:
 messenger.send_can_message(id: 0x123, data: [0xDE, 0xAD, 0xBE, 0xEF])
 ```
 
+> **Note:** Under the hood, the gem now writes CAN frames to a raw socket instead of calling `cansend`. No external dependencies are required beyond raw-socket permissions.
+
 ### Receiving CAN Messages
 
 To listen for incoming messages, set up a listener:
 
 ```ruby
 messenger.start_listening do |message|
-    puts "Received: ID=#{message[:id]}, Data=#{message[:data]}"
+  puts "Received: ID=#{message[:id]}, Data=#{message[:data]}"
 end
 ```
 
@@ -69,31 +77,29 @@ end
 
 The `start_listening` method supports filtering incoming messages based on CAN ID:
 
-Single CAN ID:
+- Single CAN ID:
 
-```ruby
-messenger.start_listening(filter: 0x123) do |message|
-  puts "Received filtered message: #{message}"
-end
-```
+  ```ruby
+  messenger.start_listening(filter: 0x123) do |message|
+    puts "Received filtered message: #{message}"
+  end
+  ```
 
-Range of CAN IDs:
+- Range of CAN IDs:
 
-```ruby
-messenger.start_listening(filter: 0x100..0x200) do |message|
-  puts "Received filtered message: #{message}"
-end
+  ```ruby
+  messenger.start_listening(filter: 0x100..0x200) do |message|
+    puts "Received filtered message: #{message}"
+  end
+  ```
 
-```
+- Array of CAN IDs:
 
-Array of CAN IDs:
-
-```ruby
-messenger.start_listening(filter: [0x123, 0x456, 0x789]) do |message|
-  puts "Received filtered message: #{message}"
-end
-
-```
+  ```ruby
+  messenger.start_listening(filter: [0x123, 0x456, 0x789]) do |message|
+    puts "Received filtered message: #{message}"
+  end
+  ```
 
 ### Stopping the Listener
 
@@ -109,51 +115,56 @@ Before using `can_messenger`, please note the following:
 
 - **Environment Requirements:**
 
+  - **SocketCAN** must be available on your Linux system.
   - **Permissions:** Working with raw sockets may require elevated privileges or membership in a specific group to open and bind to CAN interfaces without running as root.
 
 - **API Changes (v1.0.0 and later):**
 
-  - **Keyword Arguments:** The Messenger API now requires keyword arguments. For example, when initializing the Messenger, use:
+  - **Keyword Arguments:** The Messenger API now requires keyword arguments. For example, when initializing the Messenger:
+
     ```ruby
     messenger = CanMessenger::Messenger.new(interface_name: 'can0')
     ```
-    Similarly, methods like `send_can_message` now require named parameters:
+
+    Similarly, methods like `send_can_message` use named parameters:
+
     ```ruby
     messenger.send_can_message(id: 0x123, data: [0xDE, 0xAD, 0xBE, 0xEF])
     ```
-    If you're upgrading from an earlier version, update your code accordingly.
+
+    If upgrading from an earlier version, update your code accordingly.
+
   - **Block Requirement for `start_listening`:**  
-    The `start_listening` method now requires a block. If no block is provided, the method logs an error and exits without processing messages. Ensure you pass a block to handle incoming CAN messages:
+    The `start_listening` method requires a block. If no block is provided, the method logs an error and exits without processing messages:
     ```ruby
     messenger.start_listening do |message|
-      # Process the message here
       puts "Received: #{message}"
     end
     ```
 
 - **Threading & Socket Management:**
 
-  - **Blocking Behavior:** The gem uses blocking socket calls and continuously listens for messages. Be sure to manage the listener's lifecycle appropriately,especially if using it in a multi-threaded application. Always call `stop_listening` to gracefully shut down the listener.
-  - **Resource Cleanup:** The socket is automatically closed when the listening loop terminates. However, you should ensure that your application stops the listener to avoid resource leaks.
+  - **Blocking Behavior:** The gem uses blocking socket calls and continuously listens for messages. Manage the listener’s lifecycle appropriately, especially in multi-threaded environments. Always call `stop_listening` to gracefully shut down the listener.
+  - **Resource Cleanup:** The socket is automatically closed when the listening loop terminates. Stop the listener to avoid resource leaks.
 
 - **Logging:**
 
-  - **Default Logger:** By default, if no logger is provided, the gem logs to standard output. For more controlled logging, pass a custom logger when initializing the Messenger.
+  - **Default Logger:** If no logger is provided, logs go to standard output. Provide a custom logger if you want more control.
 
 - **CAN Frame Format Assumptions:**
-  - The gem expects a standard CAN frame format with a minimum frame size and specific layout (e.g., the first 4 bytes for the CAN ID, followed by a byte indicating data length, etc.). If you work with non-standard frames, you may need to adjust the implementation.
-
-By keeping these points in mind, you can avoid common pitfalls and ensure that `can_messenger` is integrated smoothly into your project.
+  - By default, the gem uses **big-endian** packing for CAN IDs. If you integrate with a system using little-endian, you may need to adjust or specify an endianness in the code.
+  - The gem expects a standard CAN frame layout (16 bytes total, with the first 4 for the ID, followed by 1 byte for DLC, 3 bytes of padding, and up to 8 bytes of data). If you work with non-standard frames or CAN FD (64-byte data), you’ll need to customize the parsing/sending logic.
 
 ## Features
 
-- **Send CAN Messages**: Send CAN messages with a specified ID.
+- **Send CAN Messages**: Send CAN messages (up to 8 data bytes).
 - **Receive CAN Messages**: Continuously listen for messages on a CAN interface.
-- **Logging**: Logs errors and events for debugging and troubleshooting.
+- **Filtering**: Optional ID filters for incoming messages (single ID, range, or array).
+- **Logging**: Logs errors and events for debugging/troubleshooting.
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test:rspec` to run the tests.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test:rspec` to execute the test suite.
 
 ## Contributing
 
@@ -161,7 +172,7 @@ Bug reports and pull requests are welcome on GitHub at [https://github.com/fk101
 
 ## License
 
-The gem is available as open-source under the terms of the MIT License.
+The gem is available as open-source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
 ## Author
 

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.0.3"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Reworked the Messenger to use raw SocketCAN sockets for sending messages instead of relying on `cansend`. This change removes the external dependency and provides more flexibility, including support for endianness configuration and direct CAN frame construction.