### PR TITLE
Bump version to 1.2.0; add explicit extended CAN ID support and updat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@
 
 - (Nothing since last release.)
 
+## [1.2.0] - 2025-02-28
+
+### Added
+
+- **Explicit extended CAN ID support**.
+  - Added an `extended_id: false` parameter to `send_can_message`, which, if set to `true`, sets the Extended Frame Format bit (bit 31) in the CAN ID.
+  - Updated `parse_frame` to detect and report `extended: true` when the EFF bit is set in incoming frames.
+  - Added corresponding tests for sending and receiving extended CAN frames.
+
+### Changed
+
+- _No breaking changes_, but internal refactoring around how CAN IDs are packed and unpacked.
+  - Removed the masking of bit 31 in `unpack_frame_id`, ensuring extended frames are no longer silently treated as standard frames.
+
+### Fixed
+
+- (Nothing since last release.)
+
 ## [1.1.0] - 2025-02-10
 
 ### Changed
@@ -86,6 +104,7 @@
 ## [0.1.0] - 2024-11-10
 
 - Initial release
+  [1.2.0]: https://github.com/fk1018/can_messenger/compare/v1.1.0...v1.2.0
   [1.1.0]: https://github.com/fk1018/can_messenger/compare/v1.0.3...v1.1.0
   [1.0.3]: https://github.com/fk1018/can_messenger/compare/v1.0.1...v1.0.3
   [1.0.1]: https://github.com/fk1018/can_messenger/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -51,13 +51,19 @@ messenger.send_can_message(id: 0x123, data: [0xDE, 0xAD, 0xBE, 0xEF])
 
 > **Note:** Under the hood, the gem now writes CAN frames to a raw socket instead of calling `cansend`. No external dependencies are required beyond raw-socket permissions.
 
-### Receiving CAN Messages
+If you need to send an extended CAN frame (29-bit ID), set extended_id: true. The gem then sets the Extended Frame Format (EFF) bit automatically:### Receiving CAN Messages
+
+```ruby
+messenger.send_can_message(id: 0x123456, data: [0x01, 0x02, 0x03], extended_id: true)
+```
+
+### Listen to CAN Messages
 
 To listen for incoming messages, set up a listener:
 
 ```ruby
-messenger.start_listening do |message|
-  puts "Received: ID=#{message[:id]}, Data=#{message[:data]}"
+messenger.start_listening do |msg|
+  puts "Received ID=0x#{msg[:id].to_s(16)}, Extended=#{msg[:extended]}, Data=#{msg[:data]}"
 end
 ```
 

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
Updated to handle extended can ids. Prior to we have been masking them.