### PR TITLE
Fix listener restart bug

### DIFF
--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -63,6 +63,8 @@ module CanMessenger
     def start_listening(filter: nil, &block)
       return @logger.error("No block provided to handle messages.") unless block_given?
 
+      @listening = true
+
       with_socket do |socket|
         @logger.info("Started listening on #{@interface_name}")
         process_message(socket, filter, &block) while @listening


### PR DESCRIPTION
## Summary
- ensure `start_listening` resets `@listening` so a messenger instance can restart
- test restarting listening after stopping

## Testing
- `bundle exec rubocop`
- `bundle exec rspec --format doc`

------
https://chatgpt.com/codex/tasks/task_e_6841ebb547c88320ad2ebb0df248b470