### PR TITLE
Update spec helper header

### DIFF
--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,4 +1,4 @@
-# test/test_helper.rb
+# spec/test_helper.rb
 # frozen_string_literal: true
 
 require "simplecov"


### PR DESCRIPTION
## Summary
- fix the header comment in `spec/test_helper.rb`

## Testing
- `bundle exec rubocop`
- `bundle exec rake test:rspec`


------
https://chatgpt.com/codex/tasks/task_e_6841ec9f3aa88320a5eb0c96b61f633c