### PR TITLE
Allow messenger to restart listening

### DIFF
--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -63,6 +63,7 @@ module CanMessenger
     def start_listening(filter: nil, &block)
       return @logger.error("No block provided to handle messages.") unless block_given?
 
+      @listening = true
       with_socket do |socket|
         @logger.info("Started listening on #{@interface_name}")
         process_message(socket, filter, &block) while @listening


### PR DESCRIPTION
## Summary
- ensure `start_listening` resets the listening flag
- test that the messenger can listen again after stopping

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_6841ecbf353483209a74f5e281f35e79