### PR TITLE
Add oversized data error spec

### DIFF
--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -43,6 +43,8 @@ module CanMessenger
         frame = build_can_frame(id: id, data: data, extended_id: extended_id)
         socket.write(frame)
       end
+    rescue ArgumentError
+      raise
     rescue StandardError => e
       @logger.error("Error sending CAN message (ID: #{id}): #{e}")
     end

--- a/spec/lib/can_messenger/messenger_spec.rb
+++ b/spec/lib/can_messenger/messenger_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe CanMessenger::Messenger do
         socket.send_can_message(id: extended_id_value, data: [0xDE, 0xAD, 0xBE, 0xEF], extended_id: true)
       end
     end
+
+    context "when data length exceeds eight bytes" do
+      it "raises ArgumentError" do
+        expect do
+          socket.send_can_message(id: 0x123, data: Array.new(9, 0xFF))
+        end.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe "#start_listening" do


### PR DESCRIPTION
## Summary
- raise `ArgumentError` from `send_can_message` when data exceeds 8 bytes
- test that sending more than 8 bytes raises `ArgumentError`

## Testing
- `bundle exec rake test:rspec`

------
https://chatgpt.com/codex/tasks/task_e_6841ece25bb08320a97ca2dfad6caf62