### PR TITLE
Add CAN FD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Added
 
-- (Nothing since last release.)
+- Optional **CAN FD** support for sending and receiving up to 64-byte frames.
 
 ### Changed
 
-- (Nothing since last release.)
+- Updated APIs to accept a `can_fd:` flag on initialization and message methods.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ If you need to send an extended CAN frame (29-bit ID), set extended_id: true. Th
 messenger.send_can_message(id: 0x123456, data: [0x01, 0x02, 0x03], extended_id: true)
 ```
 
+If you need to work with **CAN FD** frames (up to 64 data bytes), enable the mode per call or when initializing the messenger:
+
+```ruby
+messenger_fd = CanMessenger::Messenger.new(interface_name: 'can0', can_fd: true)
+messenger_fd.send_can_message(id: 0x123, data: Array.new(12, 0xFF))
+# Or on demand
+messenger.send_can_message(id: 0x123, data: Array.new(12, 0xFF), can_fd: true)
+```
+
 ### Receiving CAN Messages
 
 To listen for incoming messages, set up a listener:
@@ -147,11 +156,11 @@ Before using `can_messenger`, please note the following:
 
 - **CAN Frame Format Assumptions:**
   - By default, the gem uses **big-endian** packing for CAN IDs. If you integrate with a system using little-endian, you may need to adjust or specify an endianness in the code.
-  - The gem expects a standard CAN frame layout (16 bytes total, with the first 4 for the ID, followed by 1 byte for DLC, 3 bytes of padding, and up to 8 bytes of data). If you work with non-standard frames or CAN FD (64-byte data), you’ll need to customize the parsing/sending logic.
+  - The gem expects a standard CAN frame layout (16 bytes total, with the first 4 for the ID, followed by 1 byte for DLC, 3 bytes of padding, and up to 8 bytes of data). **CAN FD** frames (up to 64 bytes) are supported when enabled.
 
 ## Features
 
-- **Send CAN Messages**: Send CAN messages (up to 8 data bytes).
+- **Send CAN Messages**: Send CAN messages (up to 8 data bytes, or 64 bytes with CAN FD enabled).
 - **Receive CAN Messages**: Continuously listen for messages on a CAN interface.
 - **Filtering**: Optional ID filters for incoming messages (single ID, range, or array).
 - **Logging**: Logs errors and events for debugging/troubleshooting.

--- a/sig/can_messenger/messenger.rbs
+++ b/sig/can_messenger/messenger.rbs
@@ -4,20 +4,31 @@ module CanMessenger
     @logger: Logger
     @listening: bool
 
-    def initialize: (interface_name: String, logger: Logger?, endianness: Symbol) -> void
-    def send_can_message: (id: Integer, data: Array[Integer]) -> void
+    def initialize: (
+        interface_name: String,
+        logger: Logger?,
+        endianness: Symbol,
+        ?can_fd: bool
+      ) -> void
+    def send_can_message: (
+        id: Integer,
+        data: Array[Integer],
+        ?extended_id: bool,
+        ?can_fd: bool
+      ) -> void
     def start_listening: (
-        ?filter: (Integer | Range[Integer] | Array[Integer])?
-      ) { (message: { id: Integer, data: Array[Integer] }) -> void } -> void
+        ?filter: (Integer | Range[Integer] | Array[Integer])?,
+        ?can_fd: bool
+      ) { (message: { id: Integer, data: Array[Integer], extended: bool }) -> void } -> void
     def stop_listening: () -> void
 
     private
 
-    def open_can_socket: () -> (Socket | nil)
-    def with_socket: () { (socket: Socket) -> void } -> void
-    def process_message: (socket: Socket, filter: (Integer | Range[Integer] | Array[Integer])?, &block: (Proc { (message: { id: Integer, data: Array[Integer] }) -> void })) -> void
-    def receive_message: (socket: Socket) -> ({ id: Integer, data: Array[Integer] } | nil)
-    def parse_frame: (frame: String) -> ({ id: Integer, data: Array[Integer] } | nil)
+    def open_can_socket: (?can_fd: bool) -> (Socket | nil)
+    def with_socket: (?can_fd: bool) { (socket: Socket) -> void } -> void
+    def process_message: (socket: Socket, filter: (Integer | Range[Integer] | Array[Integer])?, bool, &block: (Proc { (message: { id: Integer, data: Array[Integer], extended: bool }) -> void })) -> void
+    def receive_message: (socket: Socket, ?can_fd: bool) -> ({ id: Integer, data: Array[Integer], extended: bool } | nil)
+    def parse_frame: (frame: String, ?can_fd: bool) -> ({ id: Integer, data: Array[Integer], extended: bool } | nil)
     def matches_filter?: (message_id: Integer, filter: (Integer | Range[Integer] | Array[Integer])?) -> bool
   end
 end


### PR DESCRIPTION
## Summary
- define CAN FD frame constants and allow enabling via initializer
- handle CAN FD sockets and frames in messenger
- update RBS definitions
- test CAN FD send/receive logic
- document CAN FD usage

## Testing
- `bundle exec rubocop`
- `bundle exec rake test:rspec`


------
https://chatgpt.com/codex/tasks/task_e_685aeae218b08320a884a17593e5cd88