### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.3.0] - 2025-06-27
+
 ### Added
 
 - Optional **CAN FD** support for sending and receiving up to 64-byte frames.
@@ -117,6 +119,7 @@
 ## [0.1.0] - 2024-11-10
 
 - Initial release
+  [1.3.0]: https://github.com/fk1018/can_messenger/compare/v1.2.1...v1.3.0
   [1.2.1]: https://github.com/fk1018/can_messenger/compare/v1.2.0...v1.2.1
   [1.2.0]: https://github.com/fk1018/can_messenger/compare/v1.1.0...v1.2.0
   [1.1.0]: https://github.com/fk1018/can_messenger/compare/v1.0.3...v1.1.0

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
+RuboCop::RakeTask.new(:rubocop)
 
 namespace :test do
   desc "Run RSpec tests"

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
## Summary
- bump version to 1.3.0
- record 1.3.0 release notes
- add changelog comparison link
- define rubocop Rake task

## Testing
- `bundle exec rubocop`
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_686da5f3367c8320ac8b860202ee0848