### PR TITLE
Add DBC send helper and encoding fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+## [1.4.0] - 2025-07-25
+
+### Added
+
+- `send_dbc_message` helper for encoding and sending messages defined in DBC files.
+
+### Changed
+
+- `send_can_message` now only accepts raw frame parameters.
+- DBC parsing code split into helper methods for clarity.
+
+### Fixed
+
+- Correct encoding of negative signal values using two's-complement.
+
 ## [1.3.0] - 2025-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Parse a DBC file and let the messenger encode and decode messages automatically:
 dbc = CanMessenger::DBC.load('example.dbc')
 
 # Encode using signal values
-messenger.send_can_message(dbc: dbc, message_name: 'Example', signals: { Speed: 100 })
+messenger.send_dbc_message(dbc: dbc, message_name: 'Example', signals: { Speed: 100 })
 
 # Decode received frames
 messenger.start_listening(dbc: dbc) do |msg|

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/sig/can_messenger/messenger.rbs
+++ b/sig/can_messenger/messenger.rbs
@@ -16,6 +16,13 @@ module CanMessenger
         ?extended_id: bool,
         ?can_fd: bool
       ) -> void
+    def send_dbc_message: (
+        message_name: String,
+        signals: Hash[untyped, untyped],
+        ?dbc: CanMessenger::DBC?,
+        ?extended_id: bool,
+        ?can_fd: bool
+      ) -> void
     def start_listening: (
         ?filter: (Integer | Range[Integer] | Array[Integer])?,
         ?can_fd: bool

--- a/spec/lib/can_messenger/messenger_spec.rb
+++ b/spec/lib/can_messenger/messenger_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe CanMessenger::Messenger do
         expect(frame[0..3]).to eq([0x00, 0x00, 0x00, 0x42].pack("C*"))
       end
 
-      socket.send_can_message(dbc: dbc, message_name: "Test", signals: { foo: 1 })
+      socket.send_dbc_message(dbc: dbc, message_name: "Test", signals: { foo: 1 })
     end
   end
 


### PR DESCRIPTION
## Summary
- add `send_dbc_message` method for convenience
- split DBC parsing into helper methods
- fix signed value encoding to use two's complement
- document new API
- bump version to 1.4.0

## Testing
- `bundle exec rspec`
- `rubocop`

------
https://chatgpt.com/codex/tasks/task_e_6882db5c6edc83208c871e435b1d8f23