### PR TITLE
Codex/update calculate bit position for big endian

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - staging
+chat:
+  auto_reply: true

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -396,6 +396,8 @@ module CanMessenger
       if endianness == :little
         start_bit + bit_offset
       else
+        # For big-endian, calculate the bit position by determining the MSB-first
+        # bit numbering within the byte and adjusting for the bit offset.
         base = ((start_bit / 8) * 8) + (7 - (start_bit % 8))
         base - bit_offset
       end

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -396,8 +396,17 @@ module CanMessenger
       if endianness == :little
         start_bit + bit_offset
       else
-        # For big-endian, calculate the bit position by determining the MSB-first
-        # bit numbering within the byte and adjusting for the bit offset.
+        # For big-endian signals, the bit numbering within a byte follows MSB-first
+        # ordering. This means that the most significant bit (MSB) is numbered 7,
+        # and the least significant bit (LSB) is numbered 0. To calculate the absolute
+        # bit position, we first determine the position of the MSB in the starting byte.
+        # 
+        # The formula ((start_bit / 8) * 8) calculates the starting byte's base bit
+        # position (aligned to the nearest multiple of 8). Adding (7 - (start_bit % 8))
+        # adjusts this base position to point to the MSB of the starting byte.
+        # 
+        # Finally, we subtract the bit offset to account for the signal's length and
+        # position within the message.
         base = ((start_bit / 8) * 8) + (7 - (start_bit % 8))
         base - bit_offset
       end

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -395,13 +395,9 @@ module CanMessenger
     def calculate_bit_position(bit_offset)
       if endianness == :little
         start_bit + bit_offset
-      elsif start_bit < length - 1
-        # Big endian: start_bit is MSB position, subtract bit_offset for LSB direction
-        # Handle edge case where start_bit might be too small for the signal length
-        start_bit + (length - 1 - bit_offset)
-      # Use the original buggy formula for backward compatibility with existing DBCs
       else
-        start_bit - bit_offset
+        base = ((start_bit / 8) * 8) + (7 - (start_bit % 8))
+        base - bit_offset
       end
     end
 


### PR DESCRIPTION
This pull request introduces configuration updates, a bug fix in bit position calculation for big-endian signals, and an additional test case to ensure correctness. The most important changes are grouped and summarized below:

### Configuration Updates:
* Added a new `.coderabbit.yaml` file to configure CodeRabbit integration. This includes settings for language, review profiles, auto-review workflows, and chat auto-reply functionality.

### Bug Fix:
* Fixed the `calculate_bit_position` method in `lib/can_messenger/dbc.rb` to correctly handle big-endian signals by adjusting the formula for MSB-first bit numbering within a byte. This resolves an issue with signals crossing byte boundaries.

### Testing Enhancements:
* Added a new test case in `spec/lib/can_messenger/dbc_spec.rb` to validate the encoding and decoding of big-endian signals that cross byte boundaries, ensuring the correctness of the updated bit position calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configuration file for AI review settings, enabling high-level summaries and chat auto-reply, and adjusting review workflows for staging branches.

* **Bug Fixes**
  * Improved the accuracy of big-endian signal handling in CAN message encoding and decoding, especially for signals crossing byte boundaries.

* **Tests**
  * Added a test to verify correct encoding and decoding of big-endian signals that span multiple bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->