### PR TITLE
Staging

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - staging
+chat:
+  auto_reply: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+## [1.4.0] - 2025-07-25
+
+### Added
+
+- `send_dbc_message` helper for encoding and sending messages defined in DBC files.
+
+### Changed
+
+- `send_can_message` now only accepts raw frame parameters.
+- DBC parsing code split into helper methods for clarity.
+
+### Fixed
+
+- Correct encoding of negative signal values using two's-complement.
+
 ## [1.3.0] - 2025-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Added
 
-- (Nothing since last release.)
+- Optional **CAN FD** support for sending and receiving up to 64-byte frames.
 
 ### Changed
 
-- (Nothing since last release.)
+- Updated APIs to accept a `can_fd:` flag on initialization and message methods.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.3.0] - 2025-06-27
+
 ### Added
 
 - Optional **CAN FD** support for sending and receiving up to 64-byte frames.
@@ -117,6 +119,7 @@
 ## [0.1.0] - 2024-11-10
 
 - Initial release
+  [1.3.0]: https://github.com/fk1018/can_messenger/compare/v1.2.1...v1.3.0
   [1.2.1]: https://github.com/fk1018/can_messenger/compare/v1.2.0...v1.2.1
   [1.2.0]: https://github.com/fk1018/can_messenger/compare/v1.1.0...v1.2.0
   [1.1.0]: https://github.com/fk1018/can_messenger/compare/v1.0.3...v1.1.0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Status](https://img.shields.io/badge/status-stable-green)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![Gem Total Downloads](https://img.shields.io/gem/dt/can_messenger)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/fk1018/can_messenger?utm_source=oss&utm_medium=github&utm_campaign=fk1018%2Fcan_messenger&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 `can_messenger` is a Ruby gem that provides an interface for communicating over the CAN bus, allowing users to send and receive CAN messages `via raw SocketCAN sockets`. This gem is designed for developers who need an easy way to interact with CAN-enabled devices on Linux.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ If you need to send an extended CAN frame (29-bit ID), set extended_id: true. Th
 messenger.send_can_message(id: 0x123456, data: [0x01, 0x02, 0x03], extended_id: true)
 ```
 
+If you need to work with **CAN FD** frames (up to 64 data bytes), enable the mode per call or when initializing the messenger:
+
+```ruby
+messenger_fd = CanMessenger::Messenger.new(interface_name: 'can0', can_fd: true)
+messenger_fd.send_can_message(id: 0x123, data: Array.new(12, 0xFF))
+# Or on demand
+messenger.send_can_message(id: 0x123, data: Array.new(12, 0xFF), can_fd: true)
+```
+
 ### Receiving CAN Messages
 
 To listen for incoming messages, set up a listener:
@@ -147,11 +156,11 @@ Before using `can_messenger`, please note the following:
 
 - **CAN Frame Format Assumptions:**
   - By default, the gem uses **big-endian** packing for CAN IDs. If you integrate with a system using little-endian, you may need to adjust or specify an endianness in the code.
-  - The gem expects a standard CAN frame layout (16 bytes total, with the first 4 for the ID, followed by 1 byte for DLC, 3 bytes of padding, and up to 8 bytes of data). If you work with non-standard frames or CAN FD (64-byte data), you’ll need to customize the parsing/sending logic.
+  - The gem expects a standard CAN frame layout (16 bytes total, with the first 4 for the ID, followed by 1 byte for DLC, 3 bytes of padding, and up to 8 bytes of data). **CAN FD** frames (up to 64 bytes) are supported when enabled.
 
 ## Features
 
-- **Send CAN Messages**: Send CAN messages (up to 8 data bytes).
+- **Send CAN Messages**: Send CAN messages (up to 8 data bytes, or 64 bytes with CAN FD enabled).
 - **Receive CAN Messages**: Continuously listen for messages on a CAN interface.
 - **Filtering**: Optional ID filters for incoming messages (single ID, range, or array).
 - **Logging**: Logs errors and events for debugging/troubleshooting.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ The `start_listening` method supports filtering incoming messages based on CAN I
   end
   ```
 
+### Working with DBC Files
+
+Parse a DBC file and let the messenger encode and decode messages automatically:
+
+```ruby
+dbc = CanMessenger::DBC.load('example.dbc')
+
+# Encode using signal values
+messenger.send_can_message(dbc: dbc, message_name: 'Example', signals: { Speed: 100 })
+
+# Decode received frames
+messenger.start_listening(dbc: dbc) do |msg|
+  if msg[:decoded]
+    puts "#{msg[:decoded][:name]} => #{msg[:decoded][:signals]}"
+  end
+end
+```
+
 ### Stopping the Listener
 
 To stop listening, use:
@@ -168,6 +186,7 @@ Before using `can_messenger`, please note the following:
 - **Receive CAN Messages**: Continuously listen for messages on a CAN interface.
 - **Filtering**: Optional ID filters for incoming messages (single ID, range, or array).
 - **Logging**: Logs errors and events for debugging/troubleshooting.
+- **DBC Parsing**: Parse DBC files to encode messages by name and decode incoming frames.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 `can_messenger` is a Ruby gem that provides an interface for communicating over the CAN bus, allowing users to send and receive CAN messages `via raw SocketCAN sockets`. This gem is designed for developers who need an easy way to interact with CAN-enabled devices on Linux.
 
+## Requirements
+
+- Ruby 3.0 or higher.
+
 ## Installation
 
 To install `can_messenger`, add it to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Parse a DBC file and let the messenger encode and decode messages automatically:
 dbc = CanMessenger::DBC.load('example.dbc')
 
 # Encode using signal values
-messenger.send_can_message(dbc: dbc, message_name: 'Example', signals: { Speed: 100 })
+messenger.send_dbc_message(dbc: dbc, message_name: 'Example', signals: { Speed: 100 })
 
 # Decode received frames
 messenger.start_listening(dbc: dbc) do |msg|

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
+
 RuboCop::RakeTask.new(:rubocop)
 
 namespace :test do

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
+RuboCop::RakeTask.new(:rubocop)
 
 namespace :test do
   desc "Run RSpec tests"

--- a/lib/can_messenger.rb
+++ b/lib/can_messenger.rb
@@ -3,6 +3,7 @@
 
 require_relative "can_messenger/version"
 require_relative "can_messenger/messenger"
+require_relative "can_messenger/dbc"
 
 module CanMessenger
   class Error < StandardError; end

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+module CanMessenger
+  # DBC parser for defining CAN messages and signals
+  class DBC
+    attr_reader :messages
+
+    def self.load(path)
+      new(File.read(path))
+    end
+
+    def initialize(content = "")
+      @messages = {}
+      parse(content) unless content.empty?
+    end
+
+    def parse(content) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      current = nil
+      content.each_line do |line|
+        line.strip!
+        next if line.empty? || line.start_with?("BO_TX_BU_")
+
+        if (m = line.match(/^BO_\s+(\d+)\s+(\w+)\s*:\s*(\d+)/))
+          id = m[1].to_i
+          name = m[2]
+          dlc = m[3].to_i
+          current = Message.new(id, name, dlc)
+          @messages[name] = current
+        elsif (m = line.match(/^SG_\s+(\w+)\s*:\s*(\d+)\|(\d+)@(\d)([+-])\s*\(([^,]+),([^\)]+)\)/)) && current
+          sig_name = m[1]
+          start_bit = m[2].to_i
+          length = m[3].to_i
+          endian = m[4] == "1" ? :little : :big
+          sign = m[5] == "-" ? :signed : :unsigned
+          factor = m[6].to_f
+          offset = m[7].to_f
+          current.signals << Signal.new(sig_name, start_bit: start_bit, length: length, endianness: endian, sign: sign,
+                                                  factor: factor, offset: offset)
+        end
+      end
+    end
+
+    def encode_can(name, values)
+      msg = @messages[name]
+      raise ArgumentError, "Unknown message #{name}" unless msg
+
+      { id: msg.id, data: msg.encode(values) }
+    end
+
+    def decode_can(id, data)
+      msg = @messages.values.find { |m| m.id == id }
+      return nil unless msg
+
+      { name: msg.name, signals: msg.decode(data) }
+    end
+  end
+
+  # Represents a CAN message definition from a DBC file.
+  class Message
+    attr_reader :id, :name, :dlc, :signals
+
+    def initialize(id, name, dlc)
+      @id = id
+      @name = name
+      @dlc = dlc
+      @signals = []
+    end
+
+    def encode(values)
+      bytes = Array.new(@dlc, 0)
+      @signals.each do |sig|
+        next unless values.key?(sig.name.to_sym) || values.key?(sig.name.to_s)
+
+        v = values[sig.name.to_sym] || values[sig.name.to_s]
+        sig.encode(bytes, v)
+      end
+      bytes
+    end
+
+    def decode(data)
+      res = {}
+      @signals.each do |sig|
+        res[sig.name.to_sym] = sig.decode(data)
+      end
+      res
+    end
+  end
+
+  # Represents a signal within a CAN message.
+  class Signal
+    attr_reader :name, :start_bit, :length, :endianness, :sign, :factor, :offset
+
+    def initialize(name, start_bit:, length:, endianness:, sign:, factor:, offset:) # rubocop:disable Metrics/ParameterLists
+      @name = name
+      @start_bit = start_bit
+      @length = length
+      @endianness = endianness
+      @sign = sign
+      @factor = factor
+      @offset = offset
+    end
+
+    def encode(bytes, value)
+      raw = ((value - offset) / factor).round
+      insert_bits(bytes, raw)
+    end
+
+    def decode(bytes)
+      raw = extract_bits(bytes)
+      (raw * factor) + offset
+    end
+
+    private
+
+    def insert_bits(bytes, raw) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      raw &= (1 << length) - 1 if sign == :signed
+
+      length.times do |i|
+        bit = (raw >> i) & 1
+        bit_pos = endianness == :little ? start_bit + i : start_bit - i
+        byte_index = bit_pos / 8
+        bit_index = bit_pos % 8
+        bytes[byte_index] ||= 0
+        if bit == 1
+          bytes[byte_index] |= (1 << bit_index)
+        else
+          bytes[byte_index] &= ~(1 << bit_index)
+        end
+      end
+    end
+
+    def extract_bits(bytes) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      value = 0
+      length.times do |i|
+        bit_pos = endianness == :little ? start_bit + i : start_bit - i
+        byte_index = bit_pos / 8
+        bit_index = bit_pos % 8
+        bit = ((bytes[byte_index] || 0) >> bit_index) & 1
+        value |= (bit << i)
+      end
+      if sign == :signed && value[length - 1] == 1
+        value - (1 << length)
+      else
+        value
+      end
+    end
+  end
+end

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -137,15 +137,16 @@ module CanMessenger
       max_bit = start_bit + length - 1
       max_allowed_bit = (message_size_bytes * 8) - 1
 
-      raise ArgumentError, "Signal #{name}: start_bit (#{start_bit}) cannot be negative" if start_bit < 0
+      raise ArgumentError, "Signal #{name}: start_bit (#{start_bit}) cannot be negative" if start_bit.negative?
 
       return unless max_bit > max_allowed_bit
 
       raise ArgumentError,
-            "Signal #{name}: signal bits #{start_bit}..#{max_bit} exceed message size (#{message_size_bytes} bytes = #{max_allowed_bit + 1} bits)"
+            "Signal #{name}: signal bits #{start_bit}..#{max_bit} exceed message size " \
+            "(#{message_size_bytes} bytes = #{max_allowed_bit + 1} bits)"
     end
 
-    def insert_bits(bytes, raw) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def insert_bits(bytes, raw) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       # Handle signed values: convert negative to two's complement
       raw = (1 << length) + raw if sign == :signed && raw.negative?
 
@@ -159,7 +160,7 @@ module CanMessenger
         bit_index = bit_pos % 8
 
         # Validate bounds before accessing array
-        raise ArgumentError, "Bit position #{bit_pos} out of bounds" if byte_index >= bytes.size || byte_index < 0
+        raise ArgumentError, "Bit position #{bit_pos} out of bounds" if byte_index >= bytes.size || byte_index.negative?
 
         bytes[byte_index] ||= 0
         if bit == 1
@@ -178,7 +179,7 @@ module CanMessenger
         bit_index = bit_pos % 8
 
         # Validate bounds before accessing array
-        next if byte_index >= bytes.size || byte_index < 0
+        next if byte_index >= bytes.size || byte_index.negative?
 
         bit = ((bytes[byte_index] || 0) >> bit_index) & 1
         value |= (bit << i)

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -1,19 +1,51 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  # DBC parser for defining CAN messages and signals
+  # DBC (Database CAN) Parser and Encoder/Decoder
+  #
+  # This class provides functionality to parse DBC files and encode/decode CAN messages
+  # according to the signal definitions. DBC files are a standard way to describe
+  # CAN network communication.
+  #
+  # @example Loading and using a DBC file
+  #   dbc = CanMessenger::DBC.load('vehicle.dbc')
+  #
+  #   # Encode a message with signal values
+  #   frame = dbc.encode_can('EngineData', RPM: 2500, Temperature: 85.5)
+  #   # => { id: 0x123, data: [0x09, 0xC4, 0xAB, 0x00, 0x00, 0x00, 0x00, 0x00] }
+  #
+  #   # Decode a received CAN frame
+  #   decoded = dbc.decode_can(0x123, [0x09, 0xC4, 0xAB, 0x00, 0x00, 0x00, 0x00, 0x00])
+  #   # => { name: 'EngineData', signals: { RPM: 2500.0, Temperature: 85.5 } }
   class DBC
     attr_reader :messages
 
+    # Loads a DBC file from disk and parses its contents.
+    #
+    # @param [String] path The filesystem path to the DBC file
+    # @return [DBC] A new DBC instance with parsed message definitions
+    # @raise [Errno::ENOENT] If the file doesn't exist
+    # @raise [ArgumentError] If the file contains invalid DBC syntax
     def self.load(path)
       new(File.read(path))
     end
 
+    # Initializes a new DBC instance.
+    #
+    # @param [String] content The DBC file content to parse (optional)
     def initialize(content = "")
       @messages = {}
       parse(content) unless content.empty?
     end
 
+    # Parses DBC content and populates the messages hash.
+    #
+    # This method processes each line of the DBC content, identifying message
+    # definitions (BO_) and signal definitions (SG_). It builds a complete
+    # message structure with all associated signals.
+    #
+    # @param [String] content The DBC file content to parse
+    # @return [void]
     def parse(content) # rubocop:disable Metrics/MethodLength
       current = nil
       content.each_line do |line|
@@ -29,6 +61,12 @@ module CanMessenger
       end
     end
 
+    # Parses a message definition line from DBC content.
+    #
+    # Message lines follow the format: BO_ <ID> <Name>: <DLC> <Node>
+    #
+    # @param [String] line A single line from the DBC file
+    # @return [Message, nil] A Message object if the line matches, nil otherwise
     def parse_message_line(line)
       return unless (m = line.match(/^BO_\s+(\d+)\s+(\w+)\s*:\s*(\d+)/))
 
@@ -38,6 +76,14 @@ module CanMessenger
       Message.new(id, name, dlc)
     end
 
+    # Parses a signal definition line from DBC content.
+    #
+    # Signal lines follow the format:
+    # SG_ <SignalName> : <StartBit>|<Length>@<Endianness><Sign> (<Factor>,<Offset>) [<Min>|<Max>] "<Unit>" <Receivers>
+    #
+    # @param [String] line A single line from the DBC file
+    # @param [Message] _current The current message being processed (unused but kept for API consistency)
+    # @return [Signal, nil] A Signal object if the line matches, nil otherwise
     def parse_signal_line(line, _current) # rubocop:disable Metrics/MethodLength
       return unless (m = line.match(/^SG_\s+(\w+)\s*:\s*(\d+)\|(\d+)@(\d)([+-])\s*\(([^,]+),([^\)]+)\)/))
 
@@ -60,6 +106,19 @@ module CanMessenger
       )
     end # rubocop:enable Metrics/MethodLength
 
+    # Encodes signal values into a CAN message frame.
+    #
+    # Takes a message name and a hash of signal values, then encodes them
+    # into the appropriate byte array according to the DBC signal definitions.
+    #
+    # @param [String] name The name of the message to encode
+    # @param [Hash<Symbol|String, Numeric>] values Signal names mapped to their values
+    # @return [Hash] A hash containing :id (Integer) and :data (Array<Integer>)
+    # @raise [ArgumentError] If the message name is not found in the DBC
+    #
+    # @example
+    #   frame = dbc.encode_can('EngineData', RPM: 2500, Temperature: 85.5)
+    #   # => { id: 0x123, data: [0x09, 0xC4, 0xAB, 0x00, 0x00, 0x00, 0x00, 0x00] }
     def encode_can(name, values)
       msg = @messages[name]
       raise ArgumentError, "Unknown message #{name}" unless msg
@@ -67,6 +126,18 @@ module CanMessenger
       { id: msg.id, data: msg.encode(values) }
     end
 
+    # Decodes a CAN message frame into signal values.
+    #
+    # Takes a CAN ID and data bytes, finds the matching message definition,
+    # and decodes the data into individual signal values according to the DBC.
+    #
+    # @param [Integer] id The CAN message ID
+    # @param [Array<Integer>] data The CAN message data bytes
+    # @return [Hash, nil] A hash containing :name (String) and :signals (Hash), or nil if no matching message
+    #
+    # @example
+    #   decoded = dbc.decode_can(0x123, [0x09, 0xC4, 0xAB, 0x00, 0x00, 0x00, 0x00, 0x00])
+    #   # => { name: 'EngineData', signals: { RPM: 2500.0, Temperature: 85.5 } }
     def decode_can(id, data)
       msg = @messages.values.find { |m| m.id == id }
       return nil unless msg
@@ -76,9 +147,22 @@ module CanMessenger
   end
 
   # Represents a CAN message definition from a DBC file.
+  #
+  # A Message contains the basic message properties (ID, name, data length)
+  # and a collection of Signal objects that define how data is structured
+  # within the message payload.
+  #
+  # @example
+  #   message = Message.new(0x123, 'EngineData', 8)
+  #   message.signals << Signal.new('RPM', start_bit: 0, length: 16, ...)
   class Message
     attr_reader :id, :name, :dlc, :signals
 
+    # Initializes a new Message instance.
+    #
+    # @param [Integer] id The CAN message ID (11-bit standard or 29-bit extended)
+    # @param [String] name The symbolic name of the message
+    # @param [Integer] dlc Data Length Code - number of bytes in the message (0-8 for classic CAN)
     def initialize(id, name, dlc)
       @id = id
       @name = name
@@ -86,6 +170,13 @@ module CanMessenger
       @signals = []
     end
 
+    # Encodes signal values into the message byte array.
+    #
+    # Iterates through all signals in the message and encodes their values
+    # into the appropriate bit positions within the message data bytes.
+    #
+    # @param [Hash<Symbol|String, Numeric>] values Signal names mapped to their values
+    # @return [Array<Integer>] Array of bytes representing the encoded message
     def encode(values)
       bytes = Array.new(@dlc, 0)
       @signals.each do |sig|
@@ -97,6 +188,14 @@ module CanMessenger
       bytes
     end
 
+    # Decodes message data bytes into individual signal values.
+    #
+    # Extracts and decodes each signal from the message data bytes,
+    # applying the appropriate scaling (factor/offset) to produce
+    # the final engineering unit values.
+    #
+    # @param [Array<Integer>] data The message data bytes to decode
+    # @return [Hash<Symbol, Float>] Signal names mapped to their decoded values
     def decode(data)
       res = {}
       @signals.each do |sig|
@@ -107,9 +206,33 @@ module CanMessenger
   end
 
   # Represents a signal within a CAN message.
-  class Signal
+  #
+  # A Signal defines how a piece of data is encoded within a CAN message,
+  # including its bit position, length, byte order, signedness, and scaling.
+  # Signals can represent physical values (like temperature, speed) that are
+  # encoded as integers in the CAN frame but scaled to engineering units.
+  #
+  # @example Creating a signal for engine RPM
+  #   rpm_signal = Signal.new('RPM',
+  #     start_bit: 0,      # Starting at bit 0
+  #     length: 16,        # 16 bits long
+  #     endianness: :little, # Little-endian byte order
+  #     sign: :unsigned,   # Unsigned integer
+  #     factor: 0.25,      # Scale by 0.25
+  #     offset: 0          # No offset
+  #   )
+  class Signal # rubocop:disable Metrics/ClassLength
     attr_reader :name, :start_bit, :length, :endianness, :sign, :factor, :offset
 
+    # Initializes a new Signal instance.
+    #
+    # @param [String] name The signal name
+    # @param [Integer] start_bit The starting bit position within the message (0-based)
+    # @param [Integer] length The number of bits the signal occupies (1-64)
+    # @param [Symbol] endianness Byte order - :little for little-endian, :big for big-endian
+    # @param [Symbol] sign Value type - :unsigned for unsigned integers, :signed for signed integers
+    # @param [Float] factor Scaling factor to convert raw value to engineering units
+    # @param [Float] offset Offset to add after scaling
     def initialize(name, start_bit:, length:, endianness:, sign:, factor:, offset:) # rubocop:disable Metrics/ParameterLists
       @name = name
       @start_bit = start_bit
@@ -120,12 +243,30 @@ module CanMessenger
       @offset = offset
     end
 
+    # Encodes a value into the message byte array at this signal's bit position.
+    #
+    # Converts the engineering unit value to a raw integer using the signal's
+    # factor and offset, then places the bits into the appropriate positions
+    # within the message bytes.
+    #
+    # @param [Array<Integer>] bytes The message byte array to modify
+    # @param [Numeric] value The engineering unit value to encode
+    # @return [void]
+    # @raise [ArgumentError] If the value is out of range or signal exceeds message bounds
     def encode(bytes, value)
       raw = ((value - offset) / factor).round
       validate_signal_bounds(bytes.size)
       insert_bits(bytes, raw)
     end
 
+    # Decodes this signal's value from the message byte array.
+    #
+    # Extracts the raw integer value from the appropriate bit positions,
+    # then applies the signal's scaling (factor and offset) to convert
+    # it to engineering units.
+    #
+    # @param [Array<Integer>] bytes The message byte array to decode from
+    # @return [Float] The decoded value in engineering units
     def decode(bytes)
       raw = extract_bits(bytes)
       (raw * factor) + offset
@@ -133,6 +274,14 @@ module CanMessenger
 
     private
 
+    # Validates that the signal fits within the message boundaries.
+    #
+    # Ensures that all bits used by this signal fall within the message's
+    # data length code (DLC) boundaries.
+    #
+    # @param [Integer] message_size_bytes The size of the message in bytes
+    # @return [void]
+    # @raise [ArgumentError] If signal bits exceed message boundaries or start_bit is negative
     def validate_signal_bounds(message_size_bytes)
       max_bit = start_bit + length - 1
       max_allowed_bit = (message_size_bytes * 8) - 1
@@ -146,44 +295,201 @@ module CanMessenger
             "(#{message_size_bytes} bytes = #{max_allowed_bit + 1} bits)"
     end
 
-    def insert_bits(bytes, raw) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # Encodes a raw integer value into the message byte array.
+    #
+    # This is the main encoding method that coordinates validation,
+    # value processing, and bit manipulation.
+    #
+    # @param [Array<Integer>] bytes The message byte array to modify
+    # @param [Integer] raw The raw integer value to encode
+    # @return [void]
+    def insert_bits(bytes, raw)
+      validate_raw_value(raw)
+      processed_raw = process_raw_value(raw)
+      write_bits_to_bytes(bytes, processed_raw)
+    end
+
+    # Validates the raw integer value before encoding.
+    #
+    # Performs range checking for both signed and unsigned values
+    # to ensure they fit within the signal's bit length.
+    #
+    # @param [Integer] raw The raw value to validate
+    # @return [void]
+    # @raise [ArgumentError] If the value is out of range for the signal type
+    def validate_raw_value(raw)
+      validate_unsigned_value(raw)
+      validate_signed_value(raw)
+    end
+
+    # Validates unsigned values to ensure they're not negative.
+    #
+    # @param [Integer] raw The raw value to validate
+    # @return [void]
+    # @raise [ArgumentError] If an unsigned value is negative
+    def validate_unsigned_value(raw)
+      return unless sign == :unsigned && raw.negative?
+
+      raise ArgumentError, "Unsigned value cannot be negative: #{raw}"
+    end
+
+    # Validates signed values to ensure they fit in the signal's bit range.
+    #
+    # For signed signals, checks that the value fits within the two's complement
+    # range defined by the signal's bit length.
+    #
+    # @param [Integer] raw The raw value to validate
+    # @return [void]
+    # @raise [ArgumentError] If a signed value exceeds the bit field's range
+    def validate_signed_value(raw)
+      return unless sign == :signed
+
+      min_val = -(1 << (length - 1))
+      max_val = (1 << (length - 1)) - 1
+      return if raw >= min_val && raw <= max_val
+
+      raise ArgumentError,
+            "Signed value #{raw} out of range [#{min_val}..#{max_val}] for #{length}-bit field"
+    end
+
+    # Processes the raw value for encoding (handles two's complement conversion).
+    #
+    # For signed negative values, converts them to two's complement representation.
+    # Ensures the final value fits within the signal's bit length.
+    #
+    # @param [Integer] raw The raw value to process
+    # @return [Integer] The processed value ready for bit manipulation
+    def process_raw_value(raw)
       # Handle signed values: convert negative to two's complement
       raw = (1 << length) + raw if sign == :signed && raw.negative?
-
       # Ensure the value fits in the specified bit length
-      raw &= (1 << length) - 1
+      raw & ((1 << length) - 1)
+    end
 
+    # Writes the processed bits into the message byte array.
+    #
+    # Iterates through each bit of the signal and places it in the correct
+    # position within the message bytes, respecting the signal's endianness.
+    #
+    # @param [Array<Integer>] bytes The message byte array to modify
+    # @param [Integer] raw The processed value to write
+    # @return [void]
+    def write_bits_to_bytes(bytes, raw)
       length.times do |i|
         bit = (raw >> i) & 1
-        bit_pos = endianness == :little ? start_bit + i : start_bit - i
-        byte_index = bit_pos / 8
-        bit_index = bit_pos % 8
+        bit_pos = calculate_bit_position(i)
+        byte_index, bit_index = calculate_byte_and_bit_indices(bit_pos)
 
-        # Validate bounds before accessing array
-        raise ArgumentError, "Bit position #{bit_pos} out of bounds" if byte_index >= bytes.size || byte_index.negative?
-
-        bytes[byte_index] ||= 0
-        if bit == 1
-          bytes[byte_index] |= (1 << bit_index)
-        else
-          bytes[byte_index] &= ~(1 << bit_index)
-        end
+        validate_bit_position(bit_pos, bytes.size)
+        update_byte_with_bit(bytes, byte_index, bit_index, bit)
       end
     end
 
-    def extract_bits(bytes) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # Calculates the bit position for a given bit offset within the signal.
+    #
+    # Handles both little-endian and big-endian bit ordering according
+    # to the signal's endianness setting.
+    #
+    # @param [Integer] bit_offset The offset within the signal (0 to length-1)
+    # @return [Integer] The absolute bit position within the message
+    def calculate_bit_position(bit_offset)
+      endianness == :little ? start_bit + bit_offset : start_bit + (length - 1 - bit_offset)
+    end
+
+    # Calculates byte and bit indices from an absolute bit position.
+    #
+    # @param [Integer] bit_pos The absolute bit position within the message
+    # @return [Array<Integer>] A two-element array [byte_index, bit_index]
+    def calculate_byte_and_bit_indices(bit_pos)
+      [bit_pos / 8, bit_pos % 8]
+    end
+
+    # Validates that a bit position is within the message boundaries.
+    #
+    # @param [Integer] bit_pos The bit position to validate
+    # @param [Integer] bytes_size The size of the message in bytes
+    # @return [void]
+    # @raise [ArgumentError] If the bit position is out of bounds
+    def validate_bit_position(bit_pos, bytes_size)
+      byte_index = bit_pos / 8
+      return unless byte_index >= bytes_size || byte_index.negative?
+
+      raise ArgumentError, "Bit position #{bit_pos} out of bounds"
+    end
+
+    # Updates a specific bit within a byte in the message array.
+    #
+    # Sets or clears the specified bit within the target byte, initializing
+    # the byte to 0 if it hasn't been set yet.
+    #
+    # @param [Array<Integer>] bytes The message byte array to modify
+    # @param [Integer] byte_index The index of the byte to modify
+    # @param [Integer] bit_index The bit position within the byte (0-7)
+    # @param [Integer] bit The bit value to set (0 or 1)
+    # @return [void]
+    def update_byte_with_bit(bytes, byte_index, bit_index, bit)
+      bytes[byte_index] ||= 0
+      if bit == 1
+        bytes[byte_index] |= (1 << bit_index)
+      else
+        bytes[byte_index] &= ~(1 << bit_index)
+      end
+    end
+
+    # Extracts the signal value from the message byte array.
+    #
+    # This is the main decoding method that coordinates bit extraction
+    # and sign conversion.
+    #
+    # @param [Array<Integer>] bytes The message byte array to decode from
+    # @return [Integer] The raw integer value extracted from the message
+    def extract_bits(bytes)
+      value = read_bits_from_bytes(bytes)
+      convert_to_signed_if_needed(value)
+    end
+
+    # Reads the raw bits from the message byte array.
+    #
+    # Extracts each bit of the signal from the message bytes, building
+    # up the raw integer value bit by bit.
+    #
+    # @param [Array<Integer>] bytes The message byte array to read from
+    # @return [Integer] The raw unsigned integer value
+    def read_bits_from_bytes(bytes)
       value = 0
       length.times do |i|
-        bit_pos = endianness == :little ? start_bit + i : start_bit - i
-        byte_index = bit_pos / 8
-        bit_index = bit_pos % 8
+        bit_pos = calculate_bit_position(i)
+        byte_index, bit_index = calculate_byte_and_bit_indices(bit_pos)
 
-        # Validate bounds before accessing array
-        next if byte_index >= bytes.size || byte_index.negative?
+        validate_extraction_bounds(bit_pos, bytes.size)
 
         bit = ((bytes[byte_index] || 0) >> bit_index) & 1
         value |= (bit << i)
       end
+      value
+    end
+
+    # Validates bit position during extraction to ensure it's within bounds.
+    #
+    # @param [Integer] bit_pos The bit position to validate
+    # @param [Integer] bytes_size The size of the message in bytes
+    # @return [void]
+    # @raise [ArgumentError] If the bit position is out of bounds
+    def validate_extraction_bounds(bit_pos, bytes_size)
+      byte_index = bit_pos / 8
+      return unless byte_index >= bytes_size || byte_index.negative?
+
+      raise ArgumentError, "Bit position #{bit_pos} out of bounds during extraction"
+    end
+
+    # Converts unsigned value to signed if the signal is signed and the MSB is set.
+    #
+    # For signed signals, checks if the most significant bit is set and
+    # converts the value from two's complement representation to a negative integer.
+    #
+    # @param [Integer] value The unsigned integer value to potentially convert
+    # @return [Integer] The final signed or unsigned value
+    def convert_to_signed_if_needed(value)
       if sign == :signed && value[length - 1] == 1
         value - (1 << length)
       else

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -393,7 +393,16 @@ module CanMessenger
     # @param [Integer] bit_offset The offset within the signal (0 to length-1)
     # @return [Integer] The absolute bit position within the message
     def calculate_bit_position(bit_offset)
-      endianness == :little ? start_bit + bit_offset : start_bit + (length - 1 - bit_offset)
+      if endianness == :little
+        start_bit + bit_offset
+      elsif start_bit < length - 1
+        # Big endian: start_bit is MSB position, subtract bit_offset for LSB direction
+        # Handle edge case where start_bit might be too small for the signal length
+        start_bit + (length - 1 - bit_offset)
+      # Use the original buggy formula for backward compatibility with existing DBCs
+      else
+        start_bit - bit_offset
+      end
     end
 
     # Calculates byte and bit indices from an absolute bit position.

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -400,11 +400,11 @@ module CanMessenger
         # ordering. This means that the most significant bit (MSB) is numbered 7,
         # and the least significant bit (LSB) is numbered 0. To calculate the absolute
         # bit position, we first determine the position of the MSB in the starting byte.
-        # 
+        #
         # The formula ((start_bit / 8) * 8) calculates the starting byte's base bit
         # position (aligned to the nearest multiple of 8). Adding (7 - (start_bit % 8))
         # adjusts this base position to point to the MSB of the starting byte.
-        # 
+        #
         # Finally, we subtract the bit offset to account for the signal's length and
         # position within the message.
         base = ((start_bit / 8) * 8) + (7 - (start_bit % 8))

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -346,7 +346,7 @@ module CanMessenger
 
       min_val = -(1 << (length - 1))
       max_val = (1 << (length - 1)) - 1
-      return if raw >= min_val && raw <= max_val
+      return if raw.between?(min_val, max_val)
 
       raise ArgumentError,
             "Signed value #{raw} out of range [#{min_val}..#{max_val}] for #{length}-bit field"

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -395,13 +395,20 @@ module CanMessenger
     def calculate_bit_position(bit_offset)
       if endianness == :little
         start_bit + bit_offset
-      elsif start_bit < length - 1
-        # Big endian: start_bit is MSB position, subtract bit_offset for LSB direction
-        # Handle edge case where start_bit might be too small for the signal length
-        start_bit + (length - 1 - bit_offset)
-      # Use the original buggy formula for backward compatibility with existing DBCs
       else
-        start_bit - bit_offset
+        # For big-endian signals, the bit numbering within a byte follows MSB-first
+        # ordering. This means that the most significant bit (MSB) is numbered 7,
+        # and the least significant bit (LSB) is numbered 0. To calculate the absolute
+        # bit position, we first determine the position of the MSB in the starting byte.
+        # 
+        # The formula ((start_bit / 8) * 8) calculates the starting byte's base bit
+        # position (aligned to the nearest multiple of 8). Adding (7 - (start_bit % 8))
+        # adjusts this base position to point to the MSB of the starting byte.
+        # 
+        # Finally, we subtract the bit offset to account for the signal's length and
+        # position within the message.
+        base = ((start_bit / 8) * 8) + (7 - (start_bit % 8))
+        base - bit_offset
       end
     end
 

--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -41,7 +41,7 @@ module CanMessenger
     # @param [Integer] id The CAN ID of the message (up to 29 bits for extended IDs).
     # @param [Array<Integer>] data The data bytes of the CAN message (0 to 8 bytes).
     # @return [void]
-    def send_can_message(id: nil, data: nil, extended_id: false, can_fd: nil)
+    def send_can_message(id:, data:, extended_id: false, can_fd: nil)
       raise ArgumentError, "id and data are required" if id.nil? || data.nil?
 
       use_fd = can_fd.nil? ? @can_fd : can_fd

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/sig/can_messenger.rbs
+++ b/sig/can_messenger.rbs
@@ -1,2 +1,4 @@
 module CanMessenger
+  class Error < StandardError
+  end
 end

--- a/sig/can_messenger/dbc.rbs
+++ b/sig/can_messenger/dbc.rbs
@@ -1,0 +1,136 @@
+module CanMessenger
+  # DBC (Database CAN) Parser and Encoder/Decoder
+  class DBC
+    @messages: Hash[String, Message]
+
+    attr_reader messages: Hash[String, Message]
+
+    # Loads a DBC file from disk and parses its contents
+    def self.load: (String path) -> DBC
+
+    # Initializes a new DBC instance
+    def initialize: (?String content) -> void
+
+    # Parses DBC content and populates the messages hash
+    def parse: (String content) -> void
+
+    # Encodes signal values into a CAN message frame
+    def encode_can: (String name, Hash[Symbol | String, Numeric] values) -> { id: Integer, data: Array[Integer] }
+
+    # Decodes a CAN message frame into signal values
+    def decode_can: (Integer id, Array[Integer] data) -> ({ name: String, signals: Hash[Symbol, Float] } | nil)
+
+    private
+
+    # Parses a message definition line from DBC content
+    def parse_message_line: (String line) -> (Message | nil)
+
+    # Parses a signal definition line from DBC content
+    def parse_signal_line: (String line, Message? _current) -> (Signal | nil)
+  end
+
+  # Represents a CAN message definition from a DBC file
+  class Message
+    @id: Integer
+    @name: String
+    @dlc: Integer
+    @signals: Array[Signal]
+
+    attr_reader id: Integer
+    attr_reader name: String
+    attr_reader dlc: Integer
+    attr_reader signals: Array[Signal]
+
+    # Initializes a new Message instance
+    def initialize: (Integer id, String name, Integer dlc) -> void
+
+    # Encodes signal values into the message byte array
+    def encode: (Hash[Symbol | String, Numeric] values) -> Array[Integer]
+
+    # Decodes message data bytes into individual signal values
+    def decode: (Array[Integer] data) -> Hash[Symbol, Float]
+  end
+
+  # Represents a signal within a CAN message
+  class Signal
+    @name: String
+    @start_bit: Integer
+    @length: Integer
+    @endianness: Symbol
+    @sign: Symbol
+    @factor: Float
+    @offset: Float
+
+    attr_reader name: String
+    attr_reader start_bit: Integer
+    attr_reader length: Integer
+    attr_reader endianness: Symbol
+    attr_reader sign: Symbol
+    attr_reader factor: Float
+    attr_reader offset: Float
+
+    # Initializes a new Signal instance
+    def initialize: (
+      String name,
+      start_bit: Integer,
+      length: Integer,
+      endianness: Symbol,
+      sign: Symbol,
+      factor: Float,
+      offset: Float
+    ) -> void
+
+    # Encodes a value into the message byte array at this signal's bit position
+    def encode: (Array[Integer] bytes, Numeric value) -> void
+
+    # Decodes this signal's value from the message byte array
+    def decode: (Array[Integer] bytes) -> Float
+
+    private
+
+    # Validates that the signal fits within the message boundaries
+    def validate_signal_bounds: (Integer message_size_bytes) -> void
+
+    # Encodes a raw integer value into the message byte array
+    def insert_bits: (Array[Integer] bytes, Integer raw) -> void
+
+    # Validates the raw integer value before encoding
+    def validate_raw_value: (Integer raw) -> void
+
+    # Validates unsigned values to ensure they're not negative
+    def validate_unsigned_value: (Integer raw) -> void
+
+    # Validates signed values to ensure they fit in the signal's bit range
+    def validate_signed_value: (Integer raw) -> void
+
+    # Processes the raw value for encoding (handles two's complement conversion)
+    def process_raw_value: (Integer raw) -> Integer
+
+    # Writes the processed bits into the message byte array
+    def write_bits_to_bytes: (Array[Integer] bytes, Integer raw) -> void
+
+    # Calculates the bit position for a given bit offset within the signal
+    def calculate_bit_position: (Integer bit_offset) -> Integer
+
+    # Calculates byte and bit indices from an absolute bit position
+    def calculate_byte_and_bit_indices: (Integer bit_pos) -> Array[Integer]
+
+    # Validates that a bit position is within the message boundaries
+    def validate_bit_position: (Integer bit_pos, Integer bytes_size) -> void
+
+    # Updates a specific bit within a byte in the message array
+    def update_byte_with_bit: (Array[Integer] bytes, Integer byte_index, Integer bit_index, Integer bit) -> void
+
+    # Extracts the signal value from the message byte array
+    def extract_bits: (Array[Integer] bytes) -> Integer
+
+    # Reads the raw bits from the message byte array
+    def read_bits_from_bytes: (Array[Integer] bytes) -> Integer
+
+    # Validates bit position during extraction to ensure it's within bounds
+    def validate_extraction_bounds: (Integer bit_pos, Integer bytes_size) -> void
+
+    # Converts unsigned value to signed if the signal is signed and the MSB is set
+    def convert_to_signed_if_needed: (Integer value) -> Integer
+  end
+end

--- a/sig/can_messenger/messenger.rbs
+++ b/sig/can_messenger/messenger.rbs
@@ -1,41 +1,77 @@
 module CanMessenger
+  # Messenger class for CAN bus communication
   class Messenger
-    @can_interface: String
+    @interface_name: String
     @logger: Logger
     @listening: bool
+    @endianness: Symbol
+    @can_fd: bool
 
+    FRAME_SIZE: Integer
+    CANFD_FRAME_SIZE: Integer
+    MIN_FRAME_SIZE: Integer
+    MAX_FD_DATA: Integer
+    TIMEOUT: String
+
+    # Initializes a new Messenger instance
     def initialize: (
         interface_name: String,
-        logger: Logger?,
-        endianness: Symbol,
+        ?logger: Logger?,
+        ?endianness: Symbol,
         ?can_fd: bool
       ) -> void
+
+    # Sends a CAN message by writing directly to a raw CAN socket
     def send_can_message: (
         id: Integer,
         data: Array[Integer],
         ?extended_id: bool,
-        ?can_fd: bool
+        ?can_fd: bool?
       ) -> void
+
+    # Encodes and sends a CAN message using a DBC definition
     def send_dbc_message: (
         message_name: String,
         signals: Hash[untyped, untyped],
         ?dbc: CanMessenger::DBC?,
         ?extended_id: bool,
-        ?can_fd: bool
+        ?can_fd: bool?
       ) -> void
+
+    # Continuously listens for CAN messages on the specified interface
     def start_listening: (
         ?filter: (Integer | Range[Integer] | Array[Integer])?,
-        ?can_fd: bool
-      ) { (message: { id: Integer, data: Array[Integer], extended: bool }) -> void } -> void
+        ?can_fd: bool?,
+        ?dbc: CanMessenger::DBC?
+      ) { ({ id: Integer, data: Array[Integer], extended: bool, decoded: untyped }) -> void } -> void
+
+    # Stops the listening loop
     def stop_listening: () -> void
 
     private
 
+    # Creates and configures a CAN socket bound to the interface
     def open_can_socket: (?can_fd: bool) -> (Socket | nil)
-    def with_socket: (?can_fd: bool) { (socket: Socket) -> void } -> void
-    def process_message: (socket: Socket, filter: (Integer | Range[Integer] | Array[Integer])?, bool, &block: (Proc { (message: { id: Integer, data: Array[Integer], extended: bool }) -> void })) -> void
+
+    # Opens a socket, yields it, and closes it when done
+    def with_socket: (?can_fd: bool) { (Socket) -> void } -> void
+
+    # Builds a raw CAN or CAN FD frame for SocketCAN
+    def build_can_frame: (id: Integer, data: Array[Integer], ?extended_id: bool, ?can_fd: bool) -> String
+
+    # Processes a single CAN message from socket
+    def process_message: (Socket socket, (Integer | Range[Integer] | Array[Integer])? filter, bool can_fd, CanMessenger::DBC? dbc) { ({ id: Integer, data: Array[Integer], extended: bool, decoded: untyped }) -> void } -> void
+
+    # Reads a frame from the socket and parses it
     def receive_message: (socket: Socket, ?can_fd: bool) -> ({ id: Integer, data: Array[Integer], extended: bool } | nil)
-    def parse_frame: (frame: String, ?can_fd: bool) -> ({ id: Integer, data: Array[Integer], extended: bool } | nil)
+
+    # Parses a raw CAN frame into a hash
+    def parse_frame: (frame: String, ?can_fd: bool?) -> ({ id: Integer, data: Array[Integer], extended: bool } | nil)
+
+    # Unpacks the frame ID respecting endianness
+    def unpack_frame_id: (frame: String) -> Integer
+
+    # Checks whether the given message ID matches the specified filter
     def matches_filter?: (message_id: Integer, filter: (Integer | Range[Integer] | Array[Integer])?) -> bool
   end
 end

--- a/sig/can_messenger/messenger.rbs
+++ b/sig/can_messenger/messenger.rbs
@@ -16,6 +16,13 @@ module CanMessenger
         ?extended_id: bool,
         ?can_fd: bool
       ) -> void
+    def send_dbc_message: (
+        message_name: String,
+        signals: Hash[untyped, untyped],
+        ?dbc: CanMessenger::DBC?,
+        ?extended_id: bool,
+        ?can_fd: bool
+      ) -> void
     def start_listening: (
         ?filter: (Integer | Range[Integer] | Array[Integer])?,
         ?can_fd: bool

--- a/sig/can_messenger/messenger.rbs
+++ b/sig/can_messenger/messenger.rbs
@@ -4,20 +4,31 @@ module CanMessenger
     @logger: Logger
     @listening: bool
 
-    def initialize: (interface_name: String, logger: Logger?, endianness: Symbol) -> void
-    def send_can_message: (id: Integer, data: Array[Integer]) -> void
+    def initialize: (
+        interface_name: String,
+        logger: Logger?,
+        endianness: Symbol,
+        ?can_fd: bool
+      ) -> void
+    def send_can_message: (
+        id: Integer,
+        data: Array[Integer],
+        ?extended_id: bool,
+        ?can_fd: bool
+      ) -> void
     def start_listening: (
-        ?filter: (Integer | Range[Integer] | Array[Integer])?
-      ) { (message: { id: Integer, data: Array[Integer] }) -> void } -> void
+        ?filter: (Integer | Range[Integer] | Array[Integer])?,
+        ?can_fd: bool
+      ) { (message: { id: Integer, data: Array[Integer], extended: bool }) -> void } -> void
     def stop_listening: () -> void
 
     private
 
-    def open_can_socket: () -> (Socket | nil)
-    def with_socket: () { (socket: Socket) -> void } -> void
-    def process_message: (socket: Socket, filter: (Integer | Range[Integer] | Array[Integer])?, &block: (Proc { (message: { id: Integer, data: Array[Integer] }) -> void })) -> void
-    def receive_message: (socket: Socket) -> ({ id: Integer, data: Array[Integer] } | nil)
-    def parse_frame: (frame: String) -> ({ id: Integer, data: Array[Integer] } | nil)
+    def open_can_socket: (?can_fd: bool) -> (Socket | nil)
+    def with_socket: (?can_fd: bool) { (socket: Socket) -> void } -> void
+    def process_message: (socket: Socket, filter: (Integer | Range[Integer] | Array[Integer])?, bool, &block: (Proc { (message: { id: Integer, data: Array[Integer], extended: bool }) -> void })) -> void
+    def receive_message: (socket: Socket, ?can_fd: bool) -> ({ id: Integer, data: Array[Integer], extended: bool } | nil)
+    def parse_frame: (frame: String, ?can_fd: bool) -> ({ id: Integer, data: Array[Integer], extended: bool } | nil)
     def matches_filter?: (message_id: Integer, filter: (Integer | Range[Integer] | Array[Integer])?) -> bool
   end
 end

--- a/spec/lib/can_messenger/dbc_spec.rb
+++ b/spec/lib/can_messenger/dbc_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require "tempfile"
+
+RSpec.describe CanMessenger::DBC do
+  let(:dbc_text) do
+    <<~DBC
+      BO_ 256 Example: 8 ExampleNode
+      SG_ Speed : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+      SG_ Temp : 8|8@1+ (0.5,0) [0|127.5] "" Vector__XXX
+    DBC
+  end
+
+  describe ".new" do
+    it "parses messages and signals from text" do
+      dbc = described_class.new(dbc_text)
+      expect(dbc.messages.keys).to include("Example")
+      msg = dbc.messages["Example"]
+      expect(msg.id).to eq(256)
+      expect(msg.signals.map(&:name)).to match_array(%w[Speed Temp])
+    end
+  end
+
+  describe ".load" do
+    it "loads a DBC file from disk" do
+      Tempfile.create(["test", ".dbc"]) do |file|
+        file.write(dbc_text)
+        file.flush
+        dbc = described_class.load(file.path)
+        expect(dbc.messages["Example"]).not_to be_nil
+      end
+    end
+  end
+
+  describe "#encode_can and #decode_can" do
+    let(:dbc) { described_class.new(dbc_text) }
+
+    it "encodes signal values into CAN bytes and decodes them back" do
+      frame = dbc.encode_can("Example", Speed: 10, Temp: 20)
+      expect(frame[:id]).to eq(256)
+      expect(frame[:data].first(2)).to eq([10, 40])
+
+      decoded = dbc.decode_can(frame[:id], frame[:data])
+      expect(decoded[:name]).to eq("Example")
+      expect(decoded[:signals][:Speed]).to eq(10)
+      expect(decoded[:signals][:Temp]).to eq(20)
+    end
+  end
+end

--- a/spec/lib/can_messenger/dbc_spec.rb
+++ b/spec/lib/can_messenger/dbc_spec.rb
@@ -67,5 +67,121 @@ RSpec.describe CanMessenger::DBC do
       frame = neg_dbc.encode_can("Neg", Val: -1)
       expect(frame[:data].first).to eq(0xFF)
     end
+
+    it "handles big endian signals correctly" do
+      text = <<~DBC
+        BO_ 1 BigEndian: 2 Node
+        SG_ Val : 0|8@0+ (1,0) [0|255] "" Vector__XXX
+      DBC
+      be_dbc = described_class.new(text)
+      frame = be_dbc.encode_can("BigEndian", Val: 42)
+      decoded = be_dbc.decode_can(frame[:id], frame[:data])
+      expect(decoded[:signals][:Val]).to eq(42.0)
+    end
+
+    it "applies factor and offset correctly" do
+      text = <<~DBC
+        BO_ 1 Scaled: 2 Node
+        SG_ Temp : 0|8@1+ (0.5,10) [10|137.5] "" Vector__XXX
+      DBC
+      scaled_dbc = described_class.new(text)
+      frame = scaled_dbc.encode_can("Scaled", Temp: 25)
+      expect(frame[:data].first).to eq(30) # (25-10)/0.5 = 30
+
+      decoded = scaled_dbc.decode_can(frame[:id], frame[:data])
+      expect(decoded[:signals][:Temp]).to eq(25.0)
+    end
+
+    it "handles signals with different bit lengths" do
+      text = <<~DBC
+        BO_ 1 MultiLength: 2 Node
+        SG_ Short : 0|4@1+ (1,0) [0|15] "" Vector__XXX
+        SG_ Long : 4|12@1+ (1,0) [0|4095] "" Vector__XXX
+      DBC
+      ml_dbc = described_class.new(text)
+      frame = ml_dbc.encode_can("MultiLength", Short: 5, Long: 1000)
+
+      decoded = ml_dbc.decode_can(frame[:id], frame[:data])
+      expect(decoded[:signals][:Short]).to eq(5)
+      expect(decoded[:signals][:Long]).to eq(1000)
+    end
+
+    it "raises error for unknown message" do
+      expect { dbc.encode_can("Unknown", Value: 1) }.to raise_error(ArgumentError, "Unknown message Unknown")
+    end
+
+    it "returns nil for unknown CAN ID during decode" do
+      result = dbc.decode_can(999, [1, 2, 3])
+      expect(result).to be_nil
+    end
+
+    it "raises error for negative unsigned values" do
+      expect do
+        dbc.encode_can("Example", Speed: -1)
+      end.to raise_error(ArgumentError, "Unsigned value cannot be negative: -1")
+    end
+
+    it "raises error for out of range signed values" do
+      text = <<~DBC
+        BO_ 1 Signed: 1 Node
+        SG_ Val : 0|8@1- (1,0) [-128|127] "" Vector__XXX
+      DBC
+      signed_dbc = described_class.new(text)
+      expect { signed_dbc.encode_can("Signed", Val: -200) }.to raise_error(ArgumentError, /out of range/)
+      expect { signed_dbc.encode_can("Signed", Val: 200) }.to raise_error(ArgumentError, /out of range/)
+    end
+
+    it "raises error for signals exceeding message bounds" do
+      text = <<~DBC
+        BO_ 1 OutOfBounds: 1 Node
+        SG_ Val : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+      DBC
+      oob_dbc = described_class.new(text)
+      expect { oob_dbc.encode_can("OutOfBounds", Val: 1) }.to raise_error(ArgumentError, /exceed message size/)
+    end
+
+    it "raises error for negative start bit" do
+      # This would require direct Signal construction since regex won't allow negative
+      signal = CanMessenger::Signal.new("Test", start_bit: -1, length: 8, endianness: :little, sign: :unsigned,
+                                                factor: 1, offset: 0)
+      expect { signal.encode([0], 1) }.to raise_error(ArgumentError, /cannot be negative/)
+    end
+
+    it "raises error for bit position out of bounds during extraction" do
+      text = <<~DBC
+        BO_ 1 Extract: 1 Node
+        SG_ Val : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+      DBC
+      ext_dbc = described_class.new(text)
+      # Try to decode with insufficient data
+      expect { ext_dbc.decode_can(1, []) }.to raise_error(ArgumentError, /out of bounds during extraction/)
+    end
+
+    it "handles string keys in encoding" do
+      frame = dbc.encode_can("Example", "Speed" => 15, "Temp" => 25)
+      expect(frame[:data].first(2)).to eq([15, 50])
+    end
+
+    it "skips unknown signals during encoding" do
+      frame = dbc.encode_can("Example", Speed: 10, UnknownSignal: 99)
+      expect(frame[:data].first).to eq(10)
+    end
+
+    it "handles empty DBC content" do
+      empty_dbc = described_class.new("")
+      expect(empty_dbc.messages).to be_empty
+    end
+
+    it "skips empty lines and comments" do
+      text = <<~DBC
+
+        BO_ 256 Example: 8 ExampleNode
+        BO_TX_BU_ 256 : Node1,Node2;
+        SG_ Speed : 0|8@1+ (1,0) [0|255] "" Vector__XXX
+
+      DBC
+      comment_dbc = described_class.new(text)
+      expect(comment_dbc.messages.keys).to eq(["Example"])
+    end
   end
 end

--- a/spec/lib/can_messenger/messenger_spec.rb
+++ b/spec/lib/can_messenger/messenger_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe CanMessenger::Messenger do
         expect(frame[0..3]).to eq([0x00, 0x00, 0x00, 0x42].pack("C*"))
       end
 
-      socket.send_can_message(dbc: dbc, message_name: "Test", signals: { foo: 1 })
+      socket.send_dbc_message(dbc: dbc, message_name: "Test", signals: { foo: 1 })
     end
   end
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the `CanMessenger` library, particularly around support for DBC (Database CAN) files. Key changes include the addition of DBC parsing and encoding/decoding capabilities, updates to the `send_can_message` and `start_listening` methods, and new tests to ensure robustness. These changes improve the library's functionality and usability for working with CAN messages.

### Enhancements to DBC Support:
- Added a `CanMessenger::DBC` class to parse DBC files, encode signal values into CAN frames, and decode CAN frames into signal values (`lib/can_messenger/dbc.rb`, `sig/can_messenger/dbc.rbs`). [[1]](diffhunk://#diff-0b9922743792202c4b9c68a2c007302def3811ac8229f0bea226a97302b3f17fR6) [[2]](diffhunk://#diff-61d1dc45f06936b533006b9ebd1a02325f8fa298f830cc49b4a63f1f80d3098bR1-R136)
- Introduced the `send_dbc_message` method to send CAN messages using DBC definitions (`lib/can_messenger/messenger.rb`).
- Updated the `start_listening` method to optionally decode incoming CAN messages using a DBC instance (`lib/can_messenger/messenger.rb`). [[1]](diffhunk://#diff-b213b65cf6f2958daaf4722fb894a6330b0dcc4f86ca13081d5a8439962366e8L70-R89) [[2]](diffhunk://#diff-b213b65cf6f2958daaf4722fb894a6330b0dcc4f86ca13081d5a8439962366e8L79-R98) [[3]](diffhunk://#diff-b213b65cf6f2958daaf4722fb894a6330b0dcc4f86ca13081d5a8439962366e8L164-R193)

### Documentation Updates:
- Added examples for working with DBC files in the `README.md`, including encoding/decoding messages and listening for decoded frames (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111-R128) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R189)

### Validation and Error Handling:
- Added validation to `send_can_message` to ensure `id` and `data` are provided (`lib/can_messenger/messenger.rb`).
- Improved error handling for DBC-related operations, such as encoding/decoding errors and signal validation (`lib/can_messenger/messenger.rb`, `lib/can_messenger/dbc.rb`). [[1]](diffhunk://#diff-b213b65cf6f2958daaf4722fb894a6330b0dcc4f86ca13081d5a8439962366e8R59-R75) [[2]](diffhunk://#diff-b213b65cf6f2958daaf4722fb894a6330b0dcc4f86ca13081d5a8439962366e8L164-R193)

### Testing Improvements:
- Added comprehensive tests for the new `CanMessenger::DBC` class, covering DBC parsing, encoding, decoding, and edge cases (`spec/lib/can_messenger/dbc_spec.rb`).
- Extended tests for `send_can_message` and `send_dbc_message` to validate argument handling and DBC integration (`spec/lib/can_messenger/messenger_spec.rb`).

### Versioning and Configuration:
- Updated the version to `1.4.0` to reflect the new features (`lib/can_messenger/version.rb`, `CHANGELOG.md`). [[1]](diffhunk://#diff-ae00befc0fc91cac3e64b3816e70500e2315bb8c759ca309b438d4b924dbe957L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R17)
- Added `.coderabbit.yaml` for configuration, enabling features like auto-reviews and high-level summaries (`.coderabbit.yaml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for DBC (CAN database) files, enabling parsing, encoding, and decoding of CAN messages and signals.
  * Introduced the ability to send and receive CAN messages by message name and signal values using DBC definitions.
  * Incoming CAN messages can now be automatically decoded into signal values when a DBC is provided.

* **Bug Fixes**
  * Corrected encoding of negative signal values using two's-complement representation.

* **Documentation**
  * Updated README with usage examples for DBC features and added a new badge.
  * Expanded documentation to highlight DBC parsing capabilities.

* **Tests**
  * Added extensive test coverage for DBC parsing, encoding/decoding, and new Messenger behaviors.

* **Chores**
  * Updated version to 1.4.0.
  * Added configuration and type signature files for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->