### PR TITLE
Update gemspec metadata and include additional files in the gem package

### DIFF
--- a/can_messenger.gemspec
+++ b/can_messenger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Files to include in the gem package
-  spec.files = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", ".gitignore"]
+  spec.files = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md"]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/can_messenger.gemspec
+++ b/can_messenger.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |spec|
   # Metadata for RubyGems
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/fk1018/can_messenger"
-  spec.metadata["changelog_uri"] = "https://github.com/fk1018/can_messenger/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Files to include in the gem package
-  spec.files = Dir["lib/**/*", "README.md"]
+  spec.files = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", ".gitignore"]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This pull request updates the `can_messenger.gemspec` file to improve metadata consistency and include additional files in the gem package.

### Metadata updates:
* Updated `source_code_uri` and `changelog_uri` to dynamically reference the `homepage` variable for consistency. (`[can_messenger.gemspecL20-R24](diffhunk://#diff-8fc71ab764a91faa1a86a9939c14bce4e781dc840551436777931d298bccb31cL20-R24)`)

### Gem packaging improvements:
* Added `LICENSE.txt`, `CHANGELOG.md`, and `.gitignore` to the list of files included in the gem package. (`[can_messenger.gemspecL20-R24](diffhunk://#diff-8fc71ab764a91faa1a86a9939c14bce4e781dc840551436777931d298bccb31cL20-R24)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gem metadata to ensure consistency in project links.
  * Expanded included files in the gem package to cover license, changelog, and gitignore files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->