### PR TITLE
Upgrade Ruby requirement to 4.0.1 and refresh tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3 # Match your Ruby version
+          ruby-version: 4.0.1 # Match your Ruby version
 
       # Step 5: Install Bundler
       - name: Install Bundler

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.5
+          ruby-version: 4.0.1
           bundler-cache: true
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 .DS_Store
 .idea/
 .vscode/
+.ruby-version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 4.0
   NewCops: enable
   SuggestExtensions: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+## [2.0.0] - 2026-02-02
+
+### Changed
+
+- **Breaking:** Require Ruby 4.0.1 or higher.
+- Update CI to run on Ruby 4.0.1.
+- Upgrade RuboCop to support Ruby 4.0 and refresh linting.
+- Minor style cleanups in DBC parsing and message listener block forwarding.
+
 ## [1.4.0] - 2025-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 ## [0.1.0] - 2024-11-10
 
 - Initial release
+  [2.0.0]: https://github.com/fk1018/can_messenger/compare/v1.3.0...v2.0.0
   [1.3.0]: https://github.com/fk1018/can_messenger/compare/v1.2.1...v1.3.0
   [1.2.1]: https://github.com/fk1018/can_messenger/compare/v1.2.0...v1.2.1
   [1.2.0]: https://github.com/fk1018/can_messenger/compare/v1.1.0...v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Minor style cleanups in DBC parsing and message listener block forwarding.
 - Extract SocketCAN logic into a dedicated adapter and add a base adapter interface.
 - Allow injecting a custom adapter into `Messenger` for alternate transports or testing.
+- **Breaking:** Default CAN ID endianness is now native (`:native`) instead of `:big`.
 
 ## [1.4.0] - 2025-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Allow injecting a custom adapter into `Messenger` for alternate transports or testing.
 - **Breaking:** Default CAN ID endianness is now native (`:native`) instead of `:big`.
 
+### Fixed
+
+- Close SocketCAN sockets when bind/setsockopt fails to avoid leaks.
+
 ## [1.4.0] - 2025-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Update CI to run on Ruby 4.0.1.
 - Upgrade RuboCop to support Ruby 4.0 and refresh linting.
 - Minor style cleanups in DBC parsing and message listener block forwarding.
+- Extract SocketCAN logic into a dedicated adapter and add a base adapter interface.
+- Allow injecting a custom adapter into `Messenger` for alternate transports or testing.
 
 ## [1.4.0] - 2025-07-25
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 # Development dependencies
 group :development do
   gem "logger", "~> 1.6"
-  gem "rubocop", "~> 1.21", require: false
+  gem "rubocop", "~> 1.81", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 # Development dependencies
 group :development do
   gem "logger", "~> 1.6"
-  gem "rubocop", "~> 1.81", require: false
+  gem "rubocop", "~> 1.84", require: false
 end

--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ To stop listening, use:
 messenger.stop_listening
 ```
 
+### Adapters
+
+`CanMessenger::Messenger` delegates low level CAN bus operations to an adapter. By default it uses the
+SocketCAN adapter which communicates with Linux CAN interfaces using raw sockets:
+
+```ruby
+messenger = CanMessenger::Messenger.new(interface_name: "can0")
+```
+
+You can provide a custom adapter via the `adapter:` option:
+
+```ruby
+my_adapter = MyCustomAdapter.new(interface_name: "can0", logger: Logger.new($stdout))
+messenger = CanMessenger::Messenger.new(interface_name: "can0", adapter: my_adapter)
+```
+
+To build your own adapter, subclass `CanMessenger::Adapter::Base` and implement the required methods
+`open_socket`, `build_can_frame`, `receive_message`, and `parse_frame`.
+
 ## Important Considerations
 
 Before using `can_messenger`, please note the following:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Before using `can_messenger`, please note the following:
   - **Default Logger:** If no logger is provided, logs go to standard output. Provide a custom logger if you want more control.
 
 - **CAN Frame Format Assumptions:**
-  - By default, the gem uses **native endianness** for CAN IDs (little-endian on most x86/ARM systems). You can override this by passing `endianness: :big` or `endianness: :little`.
+  - By default, the gem uses **native endianness** for CAN IDs (little-endian on most x86/ARM systems). **Changed in v2.0.0:** this default was previously `:big`. You can override this by passing `endianness: :big` or `endianness: :little`.
   - The gem expects a standard CAN frame layout (16 bytes total, with the first 4 for the ID, followed by 1 byte for DLC, 3 bytes of padding, and up to 8 bytes of data). **CAN FD** frames (up to 64 bytes) are supported when enabled.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ messenger.stop_listening
 
 ### Adapters
 
-`CanMessenger::Messenger` delegates low level CAN bus operations to an adapter. By default it uses the
+`CanMessenger::Messenger` delegates low-level CAN bus operations to an adapter. By default it uses the
 SocketCAN adapter which communicates with Linux CAN interfaces using raw sockets:
 
 ```ruby
@@ -159,12 +159,10 @@ To build your own adapter, subclass `CanMessenger::Adapter::Base` and implement 
 Before using `can_messenger`, please note the following:
 
 - **Environment Requirements:**
-
   - **SocketCAN** must be available on your Linux system.
   - **Permissions:** Working with raw sockets may require elevated privileges or membership in a specific group to open and bind to CAN interfaces without running as root.
 
 - **API Changes (v1.0.0 and later):**
-
   - **Keyword Arguments:** The Messenger API now requires keyword arguments. For example, when initializing the Messenger:
 
     ```ruby
@@ -188,16 +186,14 @@ Before using `can_messenger`, please note the following:
     ```
 
 - **Threading & Socket Management:**
-
   - **Blocking Behavior:** The gem uses blocking socket calls and continuously listens for messages. Manage the listener’s lifecycle appropriately, especially in multi-threaded environments. Always call `stop_listening` to gracefully shut down the listener.
   - **Resource Cleanup:** The socket is automatically closed when the listening loop terminates. Stop the listener to avoid resource leaks.
 
 - **Logging:**
-
   - **Default Logger:** If no logger is provided, logs go to standard output. Provide a custom logger if you want more control.
 
 - **CAN Frame Format Assumptions:**
-  - By default, the gem uses **big-endian** packing for CAN IDs. If you integrate with a system using little-endian, you may need to adjust or specify an endianness in the code.
+  - By default, the gem uses **native endianness** for CAN IDs (little-endian on most x86/ARM systems). You can override this by passing `endianness: :big` or `endianness: :little`.
   - The gem expects a standard CAN frame layout (16 bytes total, with the first 4 for the ID, followed by 1 byte for DLC, 3 bytes of padding, and up to 8 bytes of data). **CAN FD** frames (up to 64 bytes) are supported when enabled.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Requirements
 
-- Ruby 3.0 or higher.
+- Ruby 4.0.1 or higher.
 
 ## Installation
 

--- a/can_messenger.gemspec
+++ b/can_messenger.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "CanMessenger provides an interface to send and receive messages over the CAN bus, useful for applications requiring CAN communication in Ruby." # rubocop:disable Layout/LineLength
   spec.homepage      = "https://github.com/fk1018/can_messenger"
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 4.0.1"
 
   # Metadata for RubyGems
   spec.metadata["allowed_push_host"] = "https://rubygems.org"

--- a/lib/can_messenger/adapter/base.rb
+++ b/lib/can_messenger/adapter/base.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module CanMessenger
+  module Adapter
+    # Base adapter defines the interface for CAN bus adapters.
+    # Concrete adapters must implement all of the methods defined here.
+    class Base
+      attr_reader :interface_name, :logger, :endianness
+
+      def initialize(interface_name:, logger:, endianness: :big)
+        @interface_name = interface_name
+        @logger = logger
+        @endianness = endianness
+      end
+
+      # Open a socket for the underlying interface.
+      # @return [Object] adapter-specific socket
+      def open_socket(can_fd: false)
+        raise NotImplementedError, "open_socket must be implemented in subclasses"
+      end
+
+      # Build a frame ready to be written to the socket.
+      def build_can_frame(id:, data:, extended_id: false, can_fd: false)
+        raise NotImplementedError, "build_can_frame must be implemented in subclasses"
+      end
+
+      # Receive and parse a frame from the socket.
+      def receive_message(socket:, can_fd: false)
+        raise NotImplementedError, "receive_message must be implemented in subclasses"
+      end
+
+      # Parse a raw frame string into a message hash.
+      def parse_frame(frame:, can_fd: false)
+        raise NotImplementedError, "parse_frame must be implemented in subclasses"
+      end
+    end
+  end
+end

--- a/lib/can_messenger/adapter/base.rb
+++ b/lib/can_messenger/adapter/base.rb
@@ -7,10 +7,19 @@ module CanMessenger
     class Base
       attr_reader :interface_name, :logger, :endianness
 
-      def initialize(interface_name:, logger:, endianness: :big)
+      def self.native_endianness
+        native = [1].pack("I")
+        return :little if native == [1].pack("V")
+        return :big if native == [1].pack("N")
+
+        # Fallback for unusual platforms.
+        native.bytes.first == 1 ? :little : :big
+      end
+
+      def initialize(interface_name:, logger:, endianness: :native)
         @interface_name = interface_name
         @logger = logger
-        @endianness = endianness
+        @endianness = endianness == :native ? self.class.native_endianness : endianness
       end
 
       # Open a socket for the underlying interface.

--- a/lib/can_messenger/adapter/base.rb
+++ b/lib/can_messenger/adapter/base.rb
@@ -8,18 +8,24 @@ module CanMessenger
       attr_reader :interface_name, :logger, :endianness
 
       def self.native_endianness
-        native = [1].pack("I")
-        return :little if native == [1].pack("V")
-        return :big if native == [1].pack("N")
+        native = pack_uint(1, "I")
+        return :little if native == pack_uint(1, "V")
+        return :big if native == pack_uint(1, "N")
 
         # Fallback for unusual platforms.
         native.bytes.first == 1 ? :little : :big
       end
 
+      def self.pack_uint(value, template)
+        [value].pack(template)
+      end
+      private_class_method :pack_uint
+
       def initialize(interface_name:, logger:, endianness: :native)
         @interface_name = interface_name
         @logger = logger
-        @endianness = endianness == :native ? self.class.native_endianness : endianness
+        normalized_endianness = normalize_endianness(endianness)
+        @endianness = normalized_endianness == :native ? self.class.native_endianness : normalized_endianness
       end
 
       # Open a socket for the underlying interface.
@@ -41,6 +47,15 @@ module CanMessenger
       # Parse a raw frame string into a message hash.
       def parse_frame(frame:, can_fd: false)
         raise NotImplementedError, "parse_frame must be implemented in subclasses"
+      end
+
+      private
+
+      def normalize_endianness(endianness)
+        normalized = endianness.is_a?(String) ? endianness.strip.downcase.to_sym : endianness
+        return normalized if %i[native little big].include?(normalized)
+
+        raise ArgumentError, "endianness must be :native, :little, or :big"
       end
     end
   end

--- a/lib/can_messenger/adapter/socketcan.rb
+++ b/lib/can_messenger/adapter/socketcan.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "socket"
+require_relative "base"
+
+module CanMessenger
+  module Adapter
+    # Adapter implementation for Linux SocketCAN interfaces.
+    class Socketcan < Base
+      FRAME_SIZE = 16
+      CANFD_FRAME_SIZE = 72
+      MIN_FRAME_SIZE = 8
+      MAX_FD_DATA = 64
+      TIMEOUT = [1, 0].pack("l_2")
+
+      # Creates and configures a CAN socket bound to the interface.
+      # rubocop:disable Metrics/MethodLength
+      def open_socket(can_fd: false)
+        Socket.open(Socket::PF_CAN, Socket::SOCK_RAW, Socket::CAN_RAW).tap do |socket|
+          socket.bind(Socket.pack_sockaddr_can(interface_name))
+          socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO, TIMEOUT)
+          if can_fd && Socket.const_defined?(:CAN_RAW_FD_FRAMES)
+            socket.setsockopt(Socket.const_defined?(:SOL_CAN_RAW) ? Socket::SOL_CAN_RAW : Socket::CAN_RAW,
+                              Socket::CAN_RAW_FD_FRAMES, 1)
+          end
+        end
+      rescue StandardError => e
+        logger.error("Error creating CAN socket on interface #{interface_name}: #{e}")
+        nil
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      # Builds a raw CAN or CAN FD frame for SocketCAN.
+      def build_can_frame(id:, data:, extended_id: false, can_fd: false) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+        if can_fd
+          raise ArgumentError, "CAN FD data cannot exceed #{MAX_FD_DATA} bytes" if data.size > MAX_FD_DATA
+        elsif data.size > 8
+          raise ArgumentError, "CAN data cannot exceed 8 bytes"
+        end
+
+        # Mask the ID to 29 bits
+        can_id = id & 0x1FFFFFFF
+        # Set bit 31 for extended frames
+        can_id |= 0x80000000 if extended_id
+
+        # Pack the ID based on endianness
+        id_bytes = endianness == :big ? [can_id].pack("L>") : [can_id].pack("V")
+
+        dlc_and_pad = [data.size, 0, 0, 0].pack("C*")
+
+        payload = if can_fd
+                    data.pack("C*").ljust(MAX_FD_DATA, "\x00")
+                  else
+                    data.pack("C*").ljust(8, "\x00")
+                  end
+
+        id_bytes + dlc_and_pad + payload
+      end
+
+      # Reads a frame from the socket and parses it into a hash.
+      def receive_message(socket:, can_fd: false)
+        frame_size = can_fd ? CANFD_FRAME_SIZE : FRAME_SIZE
+        frame = socket.recv(frame_size)
+        return nil if frame.nil? || frame.size < MIN_FRAME_SIZE
+
+        parse_frame(frame: frame, can_fd: can_fd)
+      rescue IO::WaitReadable
+        nil
+      rescue StandardError => e
+        logger.error("Error receiving CAN message on interface #{interface_name}: #{e}")
+        nil
+      end
+
+      # Parses a raw CAN frame string into a hash with id, data and extended flag.
+      def parse_frame(frame:, can_fd: nil) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+        return nil unless frame && frame.size >= MIN_FRAME_SIZE
+
+        use_fd = can_fd.nil? ? frame.size >= CANFD_FRAME_SIZE : can_fd
+
+        raw_id = unpack_frame_id(frame: frame)
+        extended = raw_id.anybits?(0x80000000)
+        id = raw_id & 0x1FFFFFFF
+
+        data_length = if use_fd
+                        frame[4].ord
+                      else
+                        frame[4].ord & 0x0F
+                      end
+
+        data = if frame.size >= MIN_FRAME_SIZE + data_length
+                 frame[MIN_FRAME_SIZE, data_length].unpack("C*")
+               else
+                 []
+               end
+
+        { id: id, data: data, extended: extended }
+      rescue StandardError => e
+        logger.error("Error parsing CAN frame: #{e}")
+        nil
+      end
+
+      private
+
+      def unpack_frame_id(frame:)
+        if endianness == :big
+          frame[0..3].unpack1("L>")
+        else
+          frame[0..3].unpack1("V")
+        end
+      end
+    end
+  end
+end

--- a/lib/can_messenger/adapter/socketcan.rb
+++ b/lib/can_messenger/adapter/socketcan.rb
@@ -14,21 +14,15 @@ module CanMessenger
       TIMEOUT = [1, 0].pack("l_2")
 
       # Creates and configures a CAN socket bound to the interface.
-      # rubocop:disable Metrics/MethodLength
       def open_socket(can_fd: false)
-        Socket.open(Socket::PF_CAN, Socket::SOCK_RAW, Socket::CAN_RAW).tap do |socket|
-          socket.bind(Socket.pack_sockaddr_can(interface_name))
-          socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO, TIMEOUT)
-          if can_fd && Socket.const_defined?(:CAN_RAW_FD_FRAMES)
-            socket.setsockopt(Socket.const_defined?(:SOL_CAN_RAW) ? Socket::SOL_CAN_RAW : Socket::CAN_RAW,
-                              Socket::CAN_RAW_FD_FRAMES, 1)
-          end
-        end
+        socket = Socket.open(Socket::PF_CAN, Socket::SOCK_RAW, Socket::CAN_RAW)
+        configure_socket(socket, can_fd: can_fd)
+        socket
       rescue StandardError => e
+        close_socket(socket)
         logger.error("Error creating CAN socket on interface #{interface_name}: #{e}")
         nil
       end
-      # rubocop:enable Metrics/MethodLength
 
       # Builds a raw CAN or CAN FD frame for SocketCAN.
       def build_can_frame(id:, data:, extended_id: false, can_fd: false) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
@@ -107,6 +101,24 @@ module CanMessenger
         else
           frame[0..3].unpack1("V")
         end
+      end
+
+      def configure_socket(socket, can_fd:)
+        socket.bind(Socket.pack_sockaddr_can(interface_name))
+        socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO, TIMEOUT)
+        return unless can_fd && Socket.const_defined?(:CAN_RAW_FD_FRAMES)
+
+        socket.setsockopt(Socket.const_defined?(:SOL_CAN_RAW) ? Socket::SOL_CAN_RAW : Socket::CAN_RAW,
+                          Socket::CAN_RAW_FD_FRAMES, 1)
+      end
+
+      def close_socket(socket)
+        return unless socket
+        return if socket.closed?
+
+        socket.close
+      rescue StandardError
+        # Ignore close errors so we can report the original failure.
       end
     end
   end

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -506,12 +506,10 @@ module CanMessenger
     # @param [Integer] value The unsigned integer value to potentially convert
     # @return [Integer] The final signed or unsigned value
     def convert_to_signed_if_needed(value)
-      index = length - 1
-      if sign == :signed && index >= 1 && value[index] == 1
-        value - (1 << length)
-      else
-        value
-      end
+      return value unless sign == :signed && length.positive?
+
+      msb_set = (value >> (length - 1)).allbits?(1)
+      msb_set ? value - (1 << length) : value
     end
   end
 end

--- a/lib/can_messenger/dbc.rb
+++ b/lib/can_messenger/dbc.rb
@@ -85,7 +85,7 @@ module CanMessenger
     # @param [Message] _current The current message being processed (unused but kept for API consistency)
     # @return [Signal, nil] A Signal object if the line matches, nil otherwise
     def parse_signal_line(line, _current) # rubocop:disable Metrics/MethodLength
-      return unless (m = line.match(/^SG_\s+(\w+)\s*:\s*(\d+)\|(\d+)@(\d)([+-])\s*\(([^,]+),([^\)]+)\)/))
+      return unless (m = line.match(/^SG_\s+(\w+)\s*:\s*(\d+)\|(\d+)@(\d)([+-])\s*\(([^,]+),([^)]+)\)/))
 
       sig_name = m[1]
       start_bit = m[2].to_i
@@ -506,7 +506,8 @@ module CanMessenger
     # @param [Integer] value The unsigned integer value to potentially convert
     # @return [Integer] The final signed or unsigned value
     def convert_to_signed_if_needed(value)
-      if sign == :signed && value[length - 1] == 1
+      index = length - 1
+      if sign == :signed && index >= 1 && value[index] == 1
         value - (1 << length)
       else
         value

--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "socket"
 require "logger"
+require_relative "adapter/socketcan"
 
 module CanMessenger
   # Messenger
@@ -15,25 +15,24 @@ module CanMessenger
   #   messenger.start_listening do |message|
   #     puts "Received: ID=#{message[:id]}, Data=#{message[:data].map { |b| '0x%02X' % b }}"
   #   end
-  class Messenger # rubocop:disable Metrics/ClassLength
-    FRAME_SIZE = 16
-    CANFD_FRAME_SIZE = 72
-    MIN_FRAME_SIZE = 8
-    MAX_FD_DATA = 64
-    TIMEOUT = [1, 0].pack("l_2")
-
+  class Messenger
     # Initializes a new Messenger instance.
     #
     # @param [String] interface_name The CAN interface to use (e.g., 'can0').
     # @param [Logger, nil] logger Optional logger for error handling and debug information.
     # @param [Symbol] endianness The endianness of the CAN ID (default: :big) can be :big or :little.
     # @return [void]
-    def initialize(interface_name:, logger: nil, endianness: :big, can_fd: false)
+    def initialize(interface_name:, logger: nil, endianness: :big, can_fd: false, adapter: Adapter::Socketcan)
       @interface_name = interface_name
       @logger = logger || Logger.new($stdout)
       @listening = true # Control flag for listening loop
       @endianness    = endianness # :big or :little
       @can_fd        = can_fd
+      @adapter = if adapter.is_a?(Class)
+                   adapter.new(interface_name: interface_name, logger: @logger, endianness: endianness)
+                 else
+                   adapter
+                 end
     end
 
     # Sends a CAN message by writing directly to a raw CAN socket
@@ -47,7 +46,7 @@ module CanMessenger
       use_fd = can_fd.nil? ? @can_fd : can_fd
 
       with_socket(can_fd: use_fd) do |socket|
-        frame = build_can_frame(id: id, data: data, extended_id: extended_id, can_fd: use_fd)
+        frame = @adapter.build_can_frame(id: id, data: data, extended_id: extended_id, can_fd: use_fd)
         socket.write(frame)
       end
     rescue ArgumentError
@@ -115,63 +114,12 @@ module CanMessenger
     # @yield [socket] An open CAN socket.
     # @return [void]
     def with_socket(can_fd: @can_fd)
-      socket = open_can_socket(can_fd: can_fd)
+      socket = @adapter.open_socket(can_fd: can_fd)
       return @logger.error("Failed to open socket, cannot continue operation.") if socket.nil?
 
       yield socket
     ensure
       socket&.close
-    end
-
-    # Creates and configures a CAN socket bound to @interface_name.
-    #
-    # @return [Socket, nil] The configured CAN socket, or nil if the socket cannot be opened.
-    def open_can_socket(can_fd: @can_fd) # rubocop:disable Metrics/MethodLength
-      socket = Socket.open(Socket::PF_CAN, Socket::SOCK_RAW, Socket::CAN_RAW)
-      socket.bind(Socket.pack_sockaddr_can(@interface_name))
-      socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO, TIMEOUT)
-      if can_fd && Socket.const_defined?(:CAN_RAW_FD_FRAMES)
-        socket.setsockopt(Socket.const_defined?(:SOL_CAN_RAW) ? Socket::SOL_CAN_RAW : Socket::CAN_RAW,
-                          Socket::CAN_RAW_FD_FRAMES, 1)
-      end
-      socket
-    rescue StandardError => e
-      @logger.error("Error creating CAN socket on interface #{@interface_name}: #{e}")
-      nil
-    end
-
-    # Builds a raw CAN or CAN FD frame for SocketCAN.
-    #
-    # @param id [Integer] the CAN ID
-    # @param data [Array<Integer>] data bytes (up to 8 for classic, 64 for CAN FD)
-    # @param can_fd [Boolean] whether to build a CAN FD frame
-    # @return [String] the packed CAN frame
-    def build_can_frame(id:, data:, extended_id: false, can_fd: false) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
-      if can_fd
-        raise ArgumentError, "CAN FD data cannot exceed #{MAX_FD_DATA} bytes" if data.size > MAX_FD_DATA
-      elsif data.size > 8
-        raise ArgumentError, "CAN data cannot exceed 8 bytes"
-      end
-
-      # Mask the ID to 29 bits
-      can_id = id & 0x1FFFFFFF
-
-      # If extended_id == true, set bit 31 (CAN_EFF_FLAG)
-      can_id |= 0x80000000 if extended_id
-
-      # Pack the 4‐byte ID (big-endian or little-endian)
-      id_bytes = @endianness == :big ? [can_id].pack("L>") : [can_id].pack("V")
-
-      # 1 byte for DLC/length, then 3 bytes for flags/reserved
-      dlc_and_pad = [data.size, 0, 0, 0].pack("C*")
-
-      payload = if can_fd
-                  data.pack("C*").ljust(MAX_FD_DATA, "\x00")
-                else
-                  data.pack("C*").ljust(8, "\x00")
-                end
-
-      id_bytes + dlc_and_pad + payload
     end
 
     # Processes a single CAN message from `socket`. Applies filter, yields to block if it matches.
@@ -181,7 +129,7 @@ module CanMessenger
     # @yield [message] Yields the message if it passes filtering.
     # @return [void]
     def process_message(socket, filter, can_fd, dbc, &block)
-      message = receive_message(socket: socket, can_fd: can_fd)
+      message = @adapter.receive_message(socket: socket, can_fd: can_fd)
       return if message.nil?
       return if filter && !matches_filter?(message_id: message[:id], filter: filter)
 
@@ -193,68 +141,6 @@ module CanMessenger
       block.call(message)
     rescue StandardError => e
       @logger.error("Unexpected error in listening loop: #{e.message}")
-    end
-
-    # Reads a frame from the socket and parses it into { id:, data: }, or nil if none is received.
-    #
-    # @param socket [Socket]
-    # @return [Hash, nil]
-    def receive_message(socket:, can_fd: false)
-      frame_size = can_fd ? CANFD_FRAME_SIZE : FRAME_SIZE
-      frame = socket.recv(frame_size)
-      return nil if frame.nil? || frame.size < MIN_FRAME_SIZE
-
-      parse_frame(frame: frame, can_fd: can_fd)
-    rescue IO::WaitReadable
-      nil
-    rescue StandardError => e
-      @logger.error("Error receiving CAN message on interface #{@interface_name}: #{e}")
-      nil
-    end
-
-    # Parses a raw CAN frame into { id: Integer, data: Array<Integer> }, or nil on error.
-    #
-    # @param [String] frame
-    # @return [Hash, nil]
-    def parse_frame(frame:, can_fd: nil) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
-      return nil unless frame && frame.size >= MIN_FRAME_SIZE
-
-      use_fd = can_fd.nil? ? frame.size >= CANFD_FRAME_SIZE : can_fd
-
-      raw_id = unpack_frame_id(frame: frame)
-
-      # Determine if EFF bit is set
-      extended = raw_id.anybits?(0x80000000)
-      # or raw_id.anybits?(0x80000000) if your Ruby version supports `Integer#anybits?`
-
-      # Now mask off everything except the lower 29 bits
-      id = raw_id & 0x1FFFFFFF
-
-      data_length = if use_fd
-                      frame[4].ord
-                    else
-                      frame[4].ord & 0x0F
-                    end
-
-      # Extract data
-      data = if frame.size >= MIN_FRAME_SIZE + data_length
-               frame[MIN_FRAME_SIZE, data_length].unpack("C*")
-             else
-               []
-             end
-
-      { id: id, data: data, extended: extended }
-    rescue StandardError => e
-      @logger.error("Error parsing CAN frame: #{e}")
-      nil
-    end
-
-    def unpack_frame_id(frame:)
-      if @endianness == :big
-        frame[0..3].unpack1("L>")
-      else
-        frame[0..3].unpack1("V")
-      end
     end
 
     # Checks whether the given message ID matches the specified filter.

--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -20,13 +20,13 @@ module CanMessenger
     #
     # @param [String] interface_name The CAN interface to use (e.g., 'can0').
     # @param [Logger, nil] logger Optional logger for error handling and debug information.
-    # @param [Symbol] endianness The endianness of the CAN ID (default: :big) can be :big or :little.
+    # @param [Symbol] endianness The endianness of the CAN ID (default: :native) can be :big, :little, or :native.
     # @return [void]
-    def initialize(interface_name:, logger: nil, endianness: :big, can_fd: false, adapter: Adapter::Socketcan)
+    def initialize(interface_name:, logger: nil, endianness: :native, can_fd: false, adapter: Adapter::Socketcan)
       @interface_name = interface_name
       @logger = logger || Logger.new($stdout)
       @listening = true # Control flag for listening loop
-      @endianness    = endianness # :big or :little
+      @endianness    = endianness # :big, :little, or :native
       @can_fd        = can_fd
       @adapter = if adapter.is_a?(Class)
                    adapter.new(interface_name: interface_name, logger: @logger, endianness: endianness)

--- a/lib/can_messenger/messenger.rb
+++ b/lib/can_messenger/messenger.rb
@@ -86,7 +86,7 @@ module CanMessenger
     #   - `:id` [Integer] the CAN message ID
     #   - `:data` [Array<Integer>] the message data bytes
     # @return [void]
-    def start_listening(filter: nil, can_fd: nil, dbc: nil, &block)
+    def start_listening(filter: nil, can_fd: nil, dbc: nil, &)
       return @logger.error("No block provided to handle messages.") unless block_given?
 
       @listening = true
@@ -95,7 +95,7 @@ module CanMessenger
 
       with_socket(can_fd: use_fd) do |socket|
         @logger.info("Started listening on #{@interface_name}")
-        process_message(socket, filter, use_fd, dbc, &block) while @listening
+        process_message(socket, filter, use_fd, dbc, &) while @listening
       end
     end
 

--- a/lib/can_messenger/version.rb
+++ b/lib/can_messenger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanMessenger
-  VERSION = "1.4.0"
+  VERSION = "2.0.0"
 end

--- a/spec/lib/can_messenger/adapter/base_spec.rb
+++ b/spec/lib/can_messenger/adapter/base_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+require "logger"
+
+RSpec.describe CanMessenger::Adapter::Base do
+  subject(:adapter) { described_class.new(interface_name: "can0", logger: Logger.new(nil)) }
+
+  it "raises NotImplementedError for open_socket" do
+    expect { adapter.open_socket }.to raise_error(NotImplementedError)
+  end
+
+  it "raises NotImplementedError for build_can_frame" do
+    expect { adapter.build_can_frame(id: 1, data: []) }.to raise_error(NotImplementedError)
+  end
+
+  it "raises NotImplementedError for receive_message" do
+    expect { adapter.receive_message(socket: nil) }.to raise_error(NotImplementedError)
+  end
+
+  it "raises NotImplementedError for parse_frame" do
+    expect { adapter.parse_frame(frame: "") }.to raise_error(NotImplementedError)
+  end
+end

--- a/spec/lib/can_messenger/adapter/base_spec.rb
+++ b/spec/lib/can_messenger/adapter/base_spec.rb
@@ -6,6 +6,36 @@ require "logger"
 RSpec.describe CanMessenger::Adapter::Base do
   subject(:adapter) { described_class.new(interface_name: "can0", logger: Logger.new(nil)) }
 
+  describe ".native_endianness" do
+    it "returns :big when native pack matches network order" do
+      original_pack = Array.instance_method(:pack)
+      allow_any_instance_of(Array).to receive(:pack) do |array, template|
+        case template
+        when "I" then "N"
+        when "V" then "V"
+        when "N" then "Z"
+        else original_pack.bind(array).call(template)
+        end
+      end
+
+      expect(described_class.native_endianness).to eq(:big)
+    end
+
+    it "falls back to byte inspection when native order is unknown" do
+      original_pack = Array.instance_method(:pack)
+      allow_any_instance_of(Array).to receive(:pack) do |array, template|
+        case template
+        when "I" then "X"
+        when "V" then "V"
+        when "N" then "N"
+        else original_pack.bind(array).call(template)
+        end
+      end
+
+      expect(described_class.native_endianness).to eq(:big)
+    end
+  end
+
   it "defaults to native endianness" do
     expect(adapter.endianness).to eq(described_class.native_endianness)
   end

--- a/spec/lib/can_messenger/adapter/base_spec.rb
+++ b/spec/lib/can_messenger/adapter/base_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe CanMessenger::Adapter::Base do
 
   describe ".native_endianness" do
     it "returns :big when native pack matches network order" do
-      original_pack = Array.instance_method(:pack)
-      allow_any_instance_of(Array).to receive(:pack) do |array, template|
+      allow(described_class).to receive(:pack_uint).and_wrap_original do |original, value, template|
         case template
         when "I" then "N"
         when "V" then "V"
         when "N" then "Z"
-        else original_pack.bind(array).call(template)
+        else original.call(value, template)
         end
       end
 
@@ -22,13 +21,12 @@ RSpec.describe CanMessenger::Adapter::Base do
     end
 
     it "falls back to byte inspection when native order is unknown" do
-      original_pack = Array.instance_method(:pack)
-      allow_any_instance_of(Array).to receive(:pack) do |array, template|
+      allow(described_class).to receive(:pack_uint).and_wrap_original do |original, value, template|
         case template
         when "I" then "X"
         when "V" then "V"
         when "N" then "N"
-        else original_pack.bind(array).call(template)
+        else original.call(value, template)
         end
       end
 

--- a/spec/lib/can_messenger/adapter/base_spec.rb
+++ b/spec/lib/can_messenger/adapter/base_spec.rb
@@ -6,6 +6,10 @@ require "logger"
 RSpec.describe CanMessenger::Adapter::Base do
   subject(:adapter) { described_class.new(interface_name: "can0", logger: Logger.new(nil)) }
 
+  it "defaults to native endianness" do
+    expect(adapter.endianness).to eq(described_class.native_endianness)
+  end
+
   it "raises NotImplementedError for open_socket" do
     expect { adapter.open_socket }.to raise_error(NotImplementedError)
   end

--- a/spec/lib/can_messenger/adapter/base_spec.rb
+++ b/spec/lib/can_messenger/adapter/base_spec.rb
@@ -9,12 +9,8 @@ RSpec.describe CanMessenger::Adapter::Base do
   describe ".native_endianness" do
     it "returns :big when native pack matches network order" do
       allow(described_class).to receive(:pack_uint).and_wrap_original do |original, value, template|
-        case template
-        when "I" then "N"
-        when "V" then "V"
-        when "N" then "Z"
-        else original.call(value, template)
-        end
+        mapping = { "I" => "N", "V" => "V", "N" => "N" }
+        mapping.fetch(template) { original.call(value, template) }
       end
 
       expect(described_class.native_endianness).to eq(:big)

--- a/spec/lib/can_messenger/adapter/socketcan_spec.rb
+++ b/spec/lib/can_messenger/adapter/socketcan_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+require "socket"
+require "logger"
+require "stringio"
+
+RSpec.describe CanMessenger::Adapter::Socketcan do
+  before(:all) do
+    Socket.const_set(:CAN_RAW, 1) unless Socket.const_defined?(:CAN_RAW)
+    Socket.const_set(:PF_CAN, 29) unless Socket.const_defined?(:PF_CAN)
+    Socket.const_set(:CAN_RAW_FD_FRAMES, 1) unless Socket.const_defined?(:CAN_RAW_FD_FRAMES)
+    Socket.const_set(:SOL_CAN_RAW, 101) unless Socket.const_defined?(:SOL_CAN_RAW)
+
+    unless Socket.respond_to?(:pack_sockaddr_can)
+      def Socket.pack_sockaddr_can(_interface)
+        "\x00" * 16
+      end
+    end
+  end
+
+  let(:interface) { "can0" }
+  let(:log_output) { StringIO.new }
+  let(:silent_logger) { Logger.new(log_output) }
+  subject(:adapter) { described_class.new(interface_name: interface, logger: silent_logger) }
+
+  # Helper frame used across tests
+  def sample_frame
+    "#{[0x12345678].pack("L>")}\x04\x00\x00\x00#{[0xDE, 0xAD, 0xBE, 0xEF].pack("C*")}"
+  end
+
+  describe "#open_socket" do
+    let(:mock_socket) { instance_double(Socket) }
+
+    before do
+      allow(Socket).to receive(:open).and_return(mock_socket)
+      allow(mock_socket).to receive(:bind)
+      allow(mock_socket).to receive(:setsockopt)
+    end
+
+    it "opens and configures a CAN socket" do
+      adapter.open_socket
+      expect(Socket).to have_received(:open).with(Socket::PF_CAN, Socket::SOCK_RAW, Socket::CAN_RAW)
+      expect(mock_socket).to have_received(:bind)
+      expect(mock_socket).to have_received(:setsockopt)
+    end
+
+    it "sets CAN_RAW_FD_FRAMES when can_fd is true" do
+      allow(mock_socket).to receive(:setsockopt)
+      adapter.open_socket(can_fd: true)
+      expect(mock_socket).to have_received(:setsockopt).with(Socket::SOL_CAN_RAW, Socket::CAN_RAW_FD_FRAMES, 1)
+    end
+
+    it "logs and returns nil on error" do
+      allow(Socket).to receive(:open).and_raise(StandardError.new("boom"))
+      expect(silent_logger).to receive(:error).with(/Error creating CAN socket/)
+      expect(adapter.open_socket).to be_nil
+    end
+  end
+
+  describe "#build_can_frame" do
+    it "packs ID little-endian when endianness is :little" do
+      le = described_class.new(interface_name: interface, logger: silent_logger, endianness: :little)
+      frame = le.build_can_frame(id: 0x12345678, data: [])
+      expect(frame[0..3]).to eq([0x78, 0x56, 0x34, 0x12].pack("C*"))
+    end
+
+    it "sets the extended ID bit" do
+      frame = adapter.build_can_frame(id: 0x1ABC, data: [], extended_id: true)
+      expect(frame[0..3].unpack1("L>") & 0x80000000).not_to be_zero
+    end
+
+    it "raises error when data length exceeds 8 bytes" do
+      expect { adapter.build_can_frame(id: 0x1, data: Array.new(9, 0xFF)) }.to raise_error(ArgumentError)
+    end
+
+    it "raises error when CAN FD data exceeds 64 bytes" do
+      expect { adapter.build_can_frame(id: 0x1, data: Array.new(65, 0xFF), can_fd: true) }.to raise_error(ArgumentError)
+    end
+
+    it "builds CAN FD frame" do
+      data = Array.new(64, 0xAA)
+      frame = adapter.build_can_frame(id: 0x123, data: data, can_fd: true)
+      expect(frame.bytesize).to eq(72)
+    end
+  end
+
+  describe "#receive_message" do
+    let(:mock_socket) { instance_double(Socket) }
+
+    it "returns parsed message" do
+      allow(mock_socket).to receive(:recv).and_return(sample_frame)
+      msg = adapter.receive_message(socket: mock_socket)
+      expect(msg).to eq(id: 0x12345678, data: [0xDE, 0xAD, 0xBE, 0xEF], extended: false)
+    end
+
+    it "handles IO::WaitReadable" do
+      allow(mock_socket).to receive(:recv).and_raise(IO::WaitReadable)
+      expect(adapter.receive_message(socket: mock_socket)).to be_nil
+    end
+
+    it "logs StandardError" do
+      allow(mock_socket).to receive(:recv).and_raise(StandardError.new("boom"))
+      expect(silent_logger).to receive(:error).with(/Error receiving CAN message/)
+      expect(adapter.receive_message(socket: mock_socket)).to be_nil
+    end
+
+    it "requests CANFD_FRAME_SIZE when can_fd true" do
+      allow(mock_socket).to receive(:recv).and_return(sample_frame)
+      adapter.receive_message(socket: mock_socket, can_fd: true)
+      expect(mock_socket).to have_received(:recv).with(described_class::CANFD_FRAME_SIZE)
+    end
+  end
+
+  describe "#parse_frame" do
+    it "identifies extended frames" do
+      eff = 0x80000000 | 0x1ABC
+      frame = [eff].pack("L>") + [4, 0, 0, 0].pack("C*") + [0, 0, 0, 0].pack("C*")
+      parsed = adapter.parse_frame(frame: frame)
+      expect(parsed[:extended]).to be true
+      expect(parsed[:id]).to eq(0x1ABC)
+    end
+
+    it "parses CAN FD frame" do
+      data = Array.new(64) { |i| i }
+      frame = [0x123].pack("L>") + [data.size, 0, 0, 0].pack("C*") + data.pack("C*")
+      parsed = adapter.parse_frame(frame: frame, can_fd: true)
+      expect(parsed).to eq(id: 0x123, data: data, extended: false)
+    end
+
+    it "returns nil for invalid frame" do
+      expect(adapter.parse_frame(frame: "\x00" * 4)).to be_nil
+    end
+
+    it "logs errors and returns nil" do
+      allow_any_instance_of(String).to receive(:unpack1).and_raise(StandardError.new("boom"))
+      expect(silent_logger).to receive(:error).with(/Error parsing CAN frame/)
+      expect(adapter.parse_frame(frame: sample_frame)).to be_nil
+    end
+  end
+end

--- a/spec/lib/can_messenger/adapter/socketcan_spec.rb
+++ b/spec/lib/can_messenger/adapter/socketcan_spec.rb
@@ -25,8 +25,16 @@ RSpec.describe CanMessenger::Adapter::Socketcan do
   subject(:adapter) { described_class.new(interface_name: interface, logger: silent_logger) }
 
   # Helper frame used across tests
+  def pack_id(id, endianness)
+    endianness == :big ? [id].pack("L>") : [id].pack("V")
+  end
+
+  def unpack_id(bytes, endianness)
+    endianness == :big ? bytes.unpack1("L>") : bytes.unpack1("V")
+  end
+
   def sample_frame
-    "#{[0x12345678].pack("L>")}\x04\x00\x00\x00#{[0xDE, 0xAD, 0xBE, 0xEF].pack("C*")}"
+    "#{pack_id(0x12345678, adapter.endianness)}\x04\x00\x00\x00#{[0xDE, 0xAD, 0xBE, 0xEF].pack("C*")}"
   end
 
   describe "#open_socket" do
@@ -59,6 +67,10 @@ RSpec.describe CanMessenger::Adapter::Socketcan do
   end
 
   describe "#build_can_frame" do
+    it "defaults to native endianness" do
+      expect(adapter.endianness).to eq(described_class.native_endianness)
+    end
+
     it "packs ID little-endian when endianness is :little" do
       le = described_class.new(interface_name: interface, logger: silent_logger, endianness: :little)
       frame = le.build_can_frame(id: 0x12345678, data: [])
@@ -67,7 +79,8 @@ RSpec.describe CanMessenger::Adapter::Socketcan do
 
     it "sets the extended ID bit" do
       frame = adapter.build_can_frame(id: 0x1ABC, data: [], extended_id: true)
-      expect(frame[0..3].unpack1("L>") & 0x80000000).not_to be_zero
+      raw_id = unpack_id(frame[0..3], adapter.endianness)
+      expect(raw_id & 0x80000000).not_to be_zero
     end
 
     it "raises error when data length exceeds 8 bytes" do
@@ -115,7 +128,7 @@ RSpec.describe CanMessenger::Adapter::Socketcan do
   describe "#parse_frame" do
     it "identifies extended frames" do
       eff = 0x80000000 | 0x1ABC
-      frame = [eff].pack("L>") + [4, 0, 0, 0].pack("C*") + [0, 0, 0, 0].pack("C*")
+      frame = pack_id(eff, adapter.endianness) + [4, 0, 0, 0].pack("C*") + [0, 0, 0, 0].pack("C*")
       parsed = adapter.parse_frame(frame: frame)
       expect(parsed[:extended]).to be true
       expect(parsed[:id]).to eq(0x1ABC)
@@ -123,7 +136,7 @@ RSpec.describe CanMessenger::Adapter::Socketcan do
 
     it "parses CAN FD frame" do
       data = Array.new(64) { |i| i }
-      frame = [0x123].pack("L>") + [data.size, 0, 0, 0].pack("C*") + data.pack("C*")
+      frame = pack_id(0x123, adapter.endianness) + [data.size, 0, 0, 0].pack("C*") + data.pack("C*")
       parsed = adapter.parse_frame(frame: frame, can_fd: true)
       expect(parsed).to eq(id: 0x123, data: data, extended: false)
     end

--- a/spec/lib/can_messenger/adapter/socketcan_spec.rb
+++ b/spec/lib/can_messenger/adapter/socketcan_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe CanMessenger::Adapter::Socketcan do
     end
 
     it "logs errors and returns nil" do
-      allow_any_instance_of(String).to receive(:unpack1).and_raise(StandardError.new("boom"))
+      allow(adapter).to receive(:unpack_frame_id).and_raise(StandardError.new("boom"))
       expect(silent_logger).to receive(:error).with(/Error parsing CAN frame/)
       expect(adapter.parse_frame(frame: sample_frame)).to be_nil
     end

--- a/spec/lib/can_messenger/messenger_spec.rb
+++ b/spec/lib/can_messenger/messenger_spec.rb
@@ -2,481 +2,88 @@
 # frozen_string_literal: true
 
 require_relative "../../test_helper"
-require "socket"
 require "logger"
 require "stringio"
 
 RSpec.describe CanMessenger::Messenger do
-  before(:all) do
-    Socket.const_set(:CAN_RAW, 1) unless Socket.const_defined?(:CAN_RAW)
-    Socket.const_set(:PF_CAN, 29) unless Socket.const_defined?(:PF_CAN)
-    Socket.const_set(:CAN_RAW_FD_FRAMES, 1) unless Socket.const_defined?(:CAN_RAW_FD_FRAMES)
-    Socket.const_set(:SOL_CAN_RAW, 101) unless Socket.const_defined?(:SOL_CAN_RAW)
-
-    # Mock pack_sockaddr_can if it's not available
-    unless Socket.respond_to?(:pack_sockaddr_can)
-      def Socket.pack_sockaddr_can(_interface)
-        "\x00" * 16 # Simulate a 16-byte packed sockaddr structure
-      end
-    end
-  end
-
   let(:interface) { "can0" }
-  # Create a silent logger that writes to a StringIO so no log output appears during tests.
   let(:log_output) { StringIO.new }
   let(:silent_logger) { Logger.new(log_output) }
-  let(:socket) { described_class.new(interface_name: interface, logger: silent_logger) }
-
-  before do
-    allow(socket).to receive(:system).and_return(true)
+  let(:mock_socket) { instance_double("Socket", write: nil, close: nil) }
+  let(:mock_adapter) do
+    instance_double(CanMessenger::Adapter::Base,
+                    open_socket: mock_socket,
+                    build_can_frame: "frame",
+                    receive_message: nil)
   end
-
-  # Define a consistent sample frame used across tests
-  def sample_frame
-    # 12-byte frame with 8-byte header and 4 bytes of data
-    "#{[0x12345678].pack("L>")}\u0004#{"\x00" * 3}#{[0xDE, 0xAD, 0xBE, 0xEF].pack("C*")}"
-  end
+  subject(:messenger) { described_class.new(interface_name: interface, logger: silent_logger, adapter: mock_adapter) }
 
   describe "#initialize" do
     it "sets the interface instance variable" do
-      expect(socket.instance_variable_get(:@interface_name)).to eq(interface)
+      expect(messenger.instance_variable_get(:@interface_name)).to eq(interface)
     end
 
     it "initializes listening as true" do
-      expect(socket.instance_variable_get(:@listening)).to be true
+      expect(messenger.instance_variable_get(:@listening)).to be true
     end
   end
 
   describe "#send_can_message" do
-    let(:mock_socket) { instance_double(Socket) }
-
-    before do
-      # Whenever the code calls `open_can_socket`, return our mock
-      allow(socket).to receive(:open_can_socket).and_return(mock_socket)
-      # We also expect the socket to be closed in `with_socket` ensure block
-      allow(mock_socket).to receive(:close)
-    end
-
-    it "builds and writes a raw CAN frame to the socket" do
-      expected_frame = [
-        0x00, 0x00, 0x01, 0x23,  # ID in big-endian
-        0x04, 0x00, 0x00, 0x00,  # DLC=4 plus 3 bytes pad
-        0xDE, 0xAD, 0xBE, 0xEF,  # The 4 data bytes
-        0x00, 0x00, 0x00, 0x00   # pad out to 8 data bytes
-      ].pack("C*")
-
-      expect(mock_socket).to receive(:write).with(expected_frame)
-
-      # Call the method
-      socket.send_can_message(id: 0x123, data: [0xDE, 0xAD, 0xBE, 0xEF])
-    end
-
-    context "when an error occurs during write" do
-      it "logs the error and does not raise" do
-        # Simulate an error on mock_socket.write
-        allow(mock_socket).to receive(:write).and_raise(StandardError, "Test error")
-
-        expect(silent_logger).to receive(:error).with(/Error sending CAN message \(ID: 291\): Test error/)
-        expect { socket.send_can_message(id: 0x123, data: [0xDE, 0xAD, 0xBE, 0xEF]) }
-          .not_to raise_error
-      end
-    end
-    context "with an extended ID" do
-      it "builds and writes a raw CAN frame with the EFF bit (bit 31) set" do
-        # Suppose we have an extended ID = 0x1ABC
-        # Setting extended_id: true should set bit 31 -> raw_id = 0x80000000 | 0x1ABC
-        extended_id_value = 0x1ABC
-        eff_bit = 0x80000000
-        raw_id = extended_id_value | eff_bit
-
-        # For big-endian, pack this in network order (N == L>):
-        # ID bytes, DLC=4, 3 pad, then data, plus 4 padding data bytes
-        expected_frame = [
-          (raw_id >> 24) & 0xFF,
-          (raw_id >> 16) & 0xFF,
-          (raw_id >> 8)  & 0xFF,
-          raw_id & 0xFF,
-
-          0x04, 0x00, 0x00, 0x00,  # DLC=4 + 3 pad
-          0xDE, 0xAD, 0xBE, 0xEF,  # 4 data bytes
-          0x00, 0x00, 0x00, 0x00   # pad to 8 data bytes
-        ].pack("C*")
-
-        expect(mock_socket).to receive(:write).with(expected_frame)
-        socket.send_can_message(id: extended_id_value, data: [0xDE, 0xAD, 0xBE, 0xEF], extended_id: true)
-      end
-    end
-
-    context "when sending a CAN FD frame" do
-      it "builds and writes a CAN FD frame to the socket" do
-        data = Array.new(64, 0xAA)
-        expected_frame = [
-          0x00, 0x00, 0x01, 0x23,
-          64, 0x00, 0x00, 0x00,
-          *Array.new(64, 0xAA)
-        ].pack("C*")
-
-        expect(mock_socket).to receive(:write).with(expected_frame)
-
-        socket.send_can_message(id: 0x123, data: data, can_fd: true)
-      end
-    end
-
-    context "when data length exceeds eight bytes" do
-      it "raises ArgumentError" do
-        expect do
-          socket.send_can_message(id: 0x123, data: Array.new(9, 0xFF))
-        end.to raise_error(ArgumentError)
-      end
-    end
-
-    it "raises ArgumentError when id is missing" do
-      expect { socket.send_can_message(data: [0x00]) }.to raise_error(ArgumentError)
-    end
-
-    it "raises ArgumentError when data is missing" do
-      expect { socket.send_can_message(id: 0x123) }.to raise_error(ArgumentError)
-    end
-
-    it "encodes a message using a dbc object" do
-      dbc = instance_double("DBC")
-      allow(dbc).to receive(:encode_can).with("Test", { foo: 1 }).and_return(id: 0x42, data: [0x01])
-
-      expect(mock_socket).to receive(:write) do |frame|
-        expect(frame[0..3]).to eq([0x00, 0x00, 0x00, 0x42].pack("C*"))
-      end
-
-      socket.send_dbc_message(dbc: dbc, message_name: "Test", signals: { foo: 1 })
+    it "builds and writes a frame via the adapter" do
+      expect(mock_adapter).to receive(:build_can_frame).with(
+        id: 0x123,
+        data: [0x01],
+        extended_id: false,
+        can_fd: false
+      ).and_return("frame")
+      expect(mock_socket).to receive(:write).with("frame")
+      messenger.send_can_message(id: 0x123, data: [0x01])
     end
   end
 
   describe "#start_listening" do
-    let(:mock_socket) { instance_double(Socket) }
-
-    before do
-      allow(socket).to receive(:open_can_socket).and_return(mock_socket)
-      allow(mock_socket).to receive(:close)
-    end
-
-    def capture_received_messages
-      received_messages = []
-      listener_thread = Thread.new do
-        socket.start_listening do |message|
-          received_messages << message
-          socket.stop_listening # Stop once a message is received to prevent an infinite loop.
-        end
+    it "yields received messages" do
+      msg = { id: 1, data: [0xAA], extended: false }
+      allow(mock_adapter).to receive(:receive_message).and_return(msg, nil)
+      received = []
+      messenger.start_listening do |message|
+        received << message
+        messenger.stop_listening
       end
-      listener_thread.join(1)
-      received_messages
+      expect(received).to eq([msg])
     end
 
-    it "yields received messages to the block" do
-      allow(mock_socket).to receive(:recv).and_return(sample_frame, nil)
-      expect(capture_received_messages).to eq([{ id: 0x12345678, extended: false, data: [0xDE, 0xAD, 0xBE, 0xEF] }])
+    it "logs an error when no block is given" do
+      expect(silent_logger).to receive(:error).with(/No block provided/)
+      messenger.start_listening
     end
+  end
 
-    it "closes the socket after listening" do
-      allow(mock_socket).to receive(:recv).and_return(nil)
-      listener_thread = Thread.new { socket.start_listening { puts "Received message" } }
-      sleep 0.2 # Let the listening loop run briefly
-      socket.stop_listening
-      listener_thread.join(1) # Wait for the thread to finish (with a timeout)
+  describe "#with_socket" do
+    it "yields the opened socket and closes it" do
+      yielded = nil
+      messenger.send(:with_socket) { |s| yielded = s }
+      expect(yielded).to eq(mock_socket)
       expect(mock_socket).to have_received(:close)
     end
 
-    it "handles IO::WaitReadable gracefully and terminates the thread" do
-      allow(mock_socket).to receive(:recv).and_raise(IO::WaitReadable)
-
-      listener_thread = Thread.new do
-        socket.start_listening
-      end
-
-      sleep 0.2 # Let the thread run briefly.
-      socket.stop_listening
-      listener_thread.join(1)
-
-      expect(listener_thread).not_to be_alive
-    end
-
-    it "handles StandardError gracefully and terminates the thread" do
-      allow(mock_socket).to receive(:recv).and_raise(StandardError)
-
-      listener_thread = Thread.new do
-        socket.start_listening
-      end
-
-      sleep 0.2 # Let the thread run briefly.
-      socket.stop_listening
-      listener_thread.join(1)
-
-      expect(listener_thread).not_to be_alive
-    end
-
-    it "can be started again after being stopped" do
-      allow(mock_socket).to receive(:recv).and_return(sample_frame, nil, sample_frame, nil)
-
-      # First run to stop the listener
-      listener_thread = Thread.new do
-        socket.start_listening do |_message|
-          socket.stop_listening
-        end
-      end
-      listener_thread.join(1)
-
-      # Reset expectation to capture messages from second run
-      received = []
-      listener_thread = Thread.new do
-        socket.start_listening do |message|
-          received << message
-          socket.stop_listening
-        end
-      end
-      listener_thread.join(1)
-
-      expect(received).to eq([{ id: 0x12345678, extended: false, data: [0xDE, 0xAD, 0xBE, 0xEF] }])
-    end
-
-    context "without a block" do
-      it "logs an error and does not open a socket" do
-        expect(socket).not_to receive(:open_can_socket)
-        expect(silent_logger).to receive(:error).with(/No block provided/)
-        socket.start_listening
-      end
+    it "logs an error when socket cannot be opened" do
+      allow(mock_adapter).to receive(:open_socket).and_return(nil)
+      expect(silent_logger).to receive(:error).with(/Failed to open socket/)
+      executed = false
+      messenger.send(:with_socket) { executed = true }
+      expect(executed).to be false
     end
   end
 
   describe "#stop_listening" do
     it "sets @listening to false" do
-      socket.stop_listening
-      expect(socket.instance_variable_get(:@listening)).to be false
-    end
-  end
-
-  describe "#open_can_socket" do
-    let(:mock_socket) { instance_double(Socket) }
-
-    before do
-      allow(Socket).to receive(:open).and_return(mock_socket)
-      allow(mock_socket).to receive(:bind)
-      allow(mock_socket).to receive(:setsockopt)
-      socket.send(:open_can_socket)
-    end
-
-    it "opens a CAN socket with the correct parameters" do
-      expect(Socket).to have_received(:open).with(Socket::PF_CAN, Socket::SOCK_RAW, Socket::CAN_RAW)
-    end
-
-    it "binds the socket to the interface" do
-      expect(mock_socket).to have_received(:bind)
-    end
-
-    it "sets the socket options" do
-      expect(mock_socket).to have_received(:setsockopt)
-    end
-
-    context "when CAN FD is enabled" do
-      it "sets the CAN_RAW_FD_FRAMES option" do
-        allow(mock_socket).to receive(:setsockopt)
-        socket.send(:open_can_socket, can_fd: true)
-        expect(mock_socket).to have_received(:setsockopt).with(Socket::SOL_CAN_RAW, Socket::CAN_RAW_FD_FRAMES, 1)
-      end
-    end
-
-    context "when an error occurs" do
-      it "rescues the error, logs it, and returns nil" do
-        allow(Socket).to receive(:open).and_raise(StandardError.new("Test error"))
-        expect(silent_logger).to receive(:error).with(/Error creating CAN socket on interface/)
-        result = socket.send(:open_can_socket)
-        expect(result).to be_nil
-      end
-    end
-  end
-
-  describe "#with_socket" do
-    let(:fake_socket) { instance_double(Socket, close: nil) }
-
-    it "yields the opened socket and closes it" do
-      allow(socket).to receive(:open_can_socket).and_return(fake_socket)
-      yielded = nil
-      socket.send(:with_socket) do |s|
-        yielded = s
-      end
-      expect(yielded).to eq(fake_socket)
-      expect(fake_socket).to have_received(:close)
-    end
-
-    it "logs an error when socket cannot be opened" do
-      allow(socket).to receive(:open_can_socket).and_return(nil)
-      expect(silent_logger).to receive(:error).with(/Failed to open socket/)
-      executed = false
-      socket.send(:with_socket) { executed = true }
-      expect(executed).to be false
-    end
-  end
-
-  describe "#build_can_frame" do
-    it "packs ID little-endian when endianness is :little" do
-      le_socket = described_class.new(interface_name: interface, logger: silent_logger, endianness: :little)
-      frame = le_socket.send(:build_can_frame, id: 0x12345678, data: [])
-      expect(frame[0..3]).to eq([0x78, 0x56, 0x34, 0x12].pack("C*"))
-    end
-
-    it "raises ArgumentError for data > 64 bytes with CAN FD" do
-      data = Array.new(65, 0xFF)
-      expect do
-        socket.send(:build_can_frame, id: 0x1, data: data, can_fd: true)
-      end.to raise_error(ArgumentError)
-    end
-  end
-
-  describe "#receive_message" do
-    let(:mock_socket) { instance_double(Socket) }
-
-    it "returns a parsed message hash from the frame" do
-      allow(mock_socket).to receive(:recv).and_return(sample_frame)
-      message = socket.send(:receive_message, socket: mock_socket)
-      expect(message).to eq(id: 0x12345678, extended: false, data: [0xDE, 0xAD, 0xBE, 0xEF])
-    end
-
-    it "returns nil if IO::WaitReadable is raised" do
-      allow(mock_socket).to receive(:recv).and_raise(IO::WaitReadable)
-      expect(socket.send(:receive_message, socket: mock_socket)).to be_nil
-    end
-
-    context "when StandardError is raised" do
-      it "rescues the error, logs it, and returns nil" do
-        allow(mock_socket).to receive(:recv).and_raise(StandardError.new("Test error"))
-        expect(silent_logger).to receive(:error).with(/Error receiving CAN message on interface/)
-        expect(socket.send(:receive_message, socket: mock_socket)).to be_nil
-      end
-    end
-
-    it "requests CANFD_FRAME_SIZE when can_fd is true" do
-      allow(mock_socket).to receive(:recv).and_return(sample_frame)
-      socket.send(:receive_message, socket: mock_socket, can_fd: true)
-      expect(mock_socket).to have_received(:recv).with(described_class::CANFD_FRAME_SIZE)
-    end
-  end
-
-  describe "#process_message" do
-    let(:mock_socket) { instance_double(Socket) }
-    let(:msg) { { id: 0x10, extended: false, data: [0x01] } }
-
-    before do
-      allow(socket).to receive(:receive_message).and_return(msg)
-    end
-
-    it "filters out unmatched messages" do
-      expect { |b| socket.send(:process_message, mock_socket, 0x20, false, nil, &b) }.not_to yield_control
-    end
-
-    it "adds decoded data when dbc provided" do
-      dbc = double("DBC", decode_can: { value: 1 })
-      yielded = nil
-      socket.send(:process_message, mock_socket, nil, false, dbc) { |m| yielded = m }
-      expect(yielded[:decoded]).to eq({ value: 1 })
-    end
-
-    it "logs exceptions from the block" do
-      expect(silent_logger).to receive(:error).with(/Unexpected error/)
-      socket.send(:process_message, mock_socket, nil, false, nil) { raise "boom" }
-    end
-
-    it "logs decode errors" do
-      dbc = double("DBC")
-      allow(dbc).to receive(:decode_can).and_raise(StandardError, "bad")
-      expect(silent_logger).to receive(:error).with(/Unexpected error/)
-      expect { socket.send(:process_message, mock_socket, nil, false, dbc) {} }.not_to raise_error # rubocop:disable Lint/EmptyBlock
-    end
-  end
-
-  describe "#parse_frame" do
-    let(:eff_bit)       { 0x80000000 }
-    let(:base_id)       { 0x1ABC }
-    let(:full_extended) { base_id | eff_bit }
-    let(:data_bytes)    { [0xDE, 0xAD, 0xBE, 0xEF] }
-
-    def build_extended_frame(raw_id, data)
-      # For big-endian: pack("N") is the same as pack("L>")
-      frame_id = [raw_id].pack("N")
-      # DLC=4, plus 3 pad
-      dlc_and_pad = [data.size, 0, 0, 0].pack("C*")
-      # data (4 bytes) + pad to 8 bytes
-      payload = data.pack("C*").ljust(8, "\x00")
-      frame_id + dlc_and_pad + payload
-    end
-
-    it "correctly identifies an extended frame and extracts the ID" do
-      raw_frame = build_extended_frame(full_extended, data_bytes)
-
-      parsed = socket.send(:parse_frame, frame: raw_frame)
-      expect(parsed).not_to be_nil
-
-      # We expect parse_frame to report extended: true
-      expect(parsed[:extended]).to eq(true)
-
-      # The final ID should be the lower 29 bits of raw_id
-      # i.e., 0x1ABC
-      expect(parsed[:id]).to eq(base_id)
-
-      expect(parsed[:data]).to eq(data_bytes)
-    end
-
-    it "parses a raw frame into an id and data" do
-      parsed = socket.send(:parse_frame, frame: sample_frame)
-      expect(parsed).to eq(id: 0x12345678, extended: false, data: [0xDE, 0xAD, 0xBE, 0xEF])
-    end
-
-    it "parses a CAN FD frame" do
-      data = Array.new(64) { |i| i }
-      raw_id = 0x123
-      frame_id = [raw_id].pack("N")
-      dlc_and_pad = [data.size, 0, 0, 0].pack("C*")
-      payload = data.pack("C*")
-      raw_frame = frame_id + dlc_and_pad + payload
-
-      parsed = socket.send(:parse_frame, frame: raw_frame, can_fd: true)
-      expect(parsed).to eq(id: raw_id, extended: false, data: data)
-    end
-
-    it "returns nil for nil frame" do
-      expect(socket.send(:parse_frame, frame: nil)).to be_nil
-    end
-
-    it "returns nil for frame shorter than MIN_FRAME_SIZE" do
-      expect(socket.send(:parse_frame, frame: "\x00" * 4)).to be_nil
-    end
-
-    it "auto-detects CAN FD by frame length" do
-      data = Array.new(64, 0)
-      frame_id = [0x123].pack("N")
-      dlc_and_pad = [data.size, 0, 0, 0].pack("C*")
-      raw_frame = frame_id + dlc_and_pad + data.pack("C*")
-      parsed = socket.send(:parse_frame, frame: raw_frame)
-      expect(parsed).to eq(id: 0x123, extended: false, data: data)
-    end
-
-    it "parses frames with little-endian IDs" do
-      le_socket = described_class.new(interface_name: interface, logger: silent_logger, endianness: :little)
-      frame = le_socket.send(:build_can_frame, id: 0x12345678, data: [0xAA])
-      parsed = le_socket.send(:parse_frame, frame: frame)
-      expect(parsed).to eq(id: 0x12345678, extended: false, data: [0xAA])
-    end
-
-    context "when an error occurs during parsing" do
-      it "rescues the error, logs it, and returns nil" do
-        # Force any call to unpack1 on any String to raise an error
-        allow_any_instance_of(String).to receive(:unpack1).and_raise(StandardError.new("Test error"))
-        expect(silent_logger).to receive(:error).with(/Error parsing CAN frame: Test error/)
-        result = socket.send(:parse_frame, frame: sample_frame)
-        expect(result).to be_nil
-      end
+      messenger.stop_listening
+      expect(messenger.instance_variable_get(:@listening)).to be false
     end
   end
 
   describe "#matches_filter?" do
-    let(:messenger) { described_class.new(interface_name: "can0", logger: silent_logger) }
-
     it "returns true when the filter is nil" do
       expect(messenger.send(:matches_filter?, message_id: 0x123, filter: nil)).to be(true)
     end
@@ -492,8 +99,8 @@ RSpec.describe CanMessenger::Messenger do
     end
 
     it "matches an array of CAN IDs" do
-      expect(messenger.send(:matches_filter?, message_id: 0x123, filter: [0x123, 0x124, 0x125])).to be(true)
-      expect(messenger.send(:matches_filter?, message_id: 0x126, filter: [0x123, 0x124, 0x125])).to be(false)
+      expect(messenger.send(:matches_filter?, message_id: 0x123, filter: [0x123, 0x124])).to be(true)
+      expect(messenger.send(:matches_filter?, message_id: 0x126, filter: [0x123, 0x124])).to be(false)
     end
   end
 end

--- a/spec/lib/can_messenger/messenger_spec.rb
+++ b/spec/lib/can_messenger/messenger_spec.rb
@@ -26,6 +26,27 @@ RSpec.describe CanMessenger::Messenger do
     it "initializes listening as true" do
       expect(messenger.instance_variable_get(:@listening)).to be true
     end
+
+    it "instantiates an adapter when a class is provided" do
+      adapter_class = Class.new do
+        attr_reader :args
+
+        def initialize(interface_name:, logger:, endianness:)
+          @args = { interface_name: interface_name, logger: logger, endianness: endianness }
+        end
+      end
+
+      instance = described_class.new(
+        interface_name: interface,
+        logger: silent_logger,
+        adapter: adapter_class,
+        endianness: :little
+      )
+      adapter = instance.instance_variable_get(:@adapter)
+
+      expect(adapter).to be_a(adapter_class)
+      expect(adapter.args).to eq(interface_name: interface, logger: silent_logger, endianness: :little)
+    end
   end
 
   describe "#send_can_message" do
@@ -38,6 +59,38 @@ RSpec.describe CanMessenger::Messenger do
       ).and_return("frame")
       expect(mock_socket).to receive(:write).with("frame")
       messenger.send_can_message(id: 0x123, data: [0x01])
+    end
+
+    it "re-raises ArgumentError from the adapter" do
+      allow(mock_adapter).to receive(:build_can_frame).and_raise(ArgumentError, "bad frame")
+      expect { messenger.send_can_message(id: 0x123, data: [0x01]) }.to raise_error(ArgumentError, "bad frame")
+    end
+
+    it "logs errors when sending fails" do
+      allow(mock_adapter).to receive(:build_can_frame).and_raise(StandardError, "boom")
+      expect(silent_logger).to receive(:error).with(/Error sending CAN message/)
+      messenger.send_can_message(id: 0x123, data: [0x01])
+    end
+  end
+
+  describe "#send_dbc_message" do
+    let(:dbc) { instance_double(CanMessenger::DBC) }
+
+    it "raises when dbc is nil" do
+      expect { messenger.send_dbc_message(message_name: "Example", signals: {}, dbc: nil) }
+        .to raise_error(ArgumentError, "dbc is required")
+    end
+
+    it "encodes and sends the message" do
+      allow(dbc).to receive(:encode_can).and_return(id: 0x321, data: [0x11])
+      expect(messenger).to receive(:send_can_message).with(id: 0x321, data: [0x11], extended_id: false, can_fd: nil)
+      messenger.send_dbc_message(message_name: "Example", signals: { speed: 1 }, dbc: dbc)
+    end
+
+    it "logs errors when encoding fails" do
+      allow(dbc).to receive(:encode_can).and_raise(StandardError, "boom")
+      expect(silent_logger).to receive(:error).with(/Error sending DBC message/)
+      messenger.send_dbc_message(message_name: "Example", signals: {}, dbc: dbc)
     end
   end
 
@@ -101,6 +154,28 @@ RSpec.describe CanMessenger::Messenger do
     it "matches an array of CAN IDs" do
       expect(messenger.send(:matches_filter?, message_id: 0x123, filter: [0x123, 0x124])).to be(true)
       expect(messenger.send(:matches_filter?, message_id: 0x126, filter: [0x123, 0x124])).to be(false)
+    end
+  end
+
+  describe "#process_message" do
+    let(:dbc) { instance_double(CanMessenger::DBC) }
+
+    it "adds decoded data when dbc is provided" do
+      message = { id: 0x123, data: [0x01] }
+      decoded = { name: "Example", signals: { speed: 1 } }
+      allow(mock_adapter).to receive(:receive_message).and_return(message)
+      allow(dbc).to receive(:decode_can).and_return(decoded)
+
+      received = nil
+      messenger.send(:process_message, mock_socket, nil, false, dbc) { |msg| received = msg }
+
+      expect(received[:decoded]).to eq(decoded)
+    end
+
+    it "logs unexpected errors" do
+      allow(mock_adapter).to receive(:receive_message).and_raise(StandardError, "boom")
+      expect(silent_logger).to receive(:error).with(/Unexpected error in listening loop/)
+      messenger.send(:process_message, mock_socket, nil, false, nil) { |_| nil }
     end
   end
 end


### PR DESCRIPTION
# Summary

- Require Ruby >= 4.0.1 and update documentation
- Bump gem version to 2.0.0 and update changelog
- Extract SocketCAN logic into adapter interface and allow custom adapters
- Update CI workflows to run on Ruby 4.0.1
- Upgrade RuboCop to support Ruby 4.0 and align linting
- Minor style fixes flagged by newer RuboCop
- Ignore local .ruby-version (developer addition)

# Testing

- bundle exec rubocop
- bundle exec rake test:rspec





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Requires Ruby 4.0.1+; release version 2.0.0. Default CAN ID endianness changed to native.

* **New Features**
  * Adapter abstraction for CAN transport with a built-in SocketCAN adapter and CAN FD support; messenger accepts a custom adapter.

* **Bug Fixes / Improvements**
  * Safer signed-value handling in DBC parsing; sockets closed on setup failures to prevent leaks.

* **Documentation**
  * README updated with adapters, endianness notes and examples.

* **Chores**
  * CI and linters updated for Ruby 4.0; ignore rules updated.

* **Tests**
  * New and updated tests for adapters and messenger adapter integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->